### PR TITLE
Enable CORS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2672,6 +2672,15 @@
         "tiny-lru": "^7.0.0"
       }
     },
+    "fastify-cors": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/fastify-cors/-/fastify-cors-4.1.0.tgz",
+      "integrity": "sha512-Vr4AgypDkRwG16cs1ORnYItZx6FMN+gCpHvP3/nzNZL1HFzf7U/NaSgmC784VqtK8yiqSXZEoTGCsmzeSp8JVw==",
+      "requires": {
+        "fastify-plugin": "^2.0.0",
+        "vary": "^1.1.2"
+      }
+    },
     "fastify-error": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/fastify-error/-/fastify-error-0.1.0.tgz",
@@ -5763,6 +5772,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "verror": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -12,14 +12,15 @@
     "!build/**/*.map"
   ],
   "dependencies": {
-    "cli-ux": "5.x.x",
     "@comunica/actor-init-sparql": "1.x.x",
     "@comunica/actor-init-sparql-rdfjs": "1.x.x",
-    "fastify": "3.x.x",
-    "fastify-gql": "5.x.x",
     "@hapi/hoek": "9.x.x",
     "@hapi/joi": "17.x.x",
     "@oclif/command": "1.x.x",
+    "cli-ux": "5.x.x",
+    "fastify": "3.x.x",
+    "fastify-cors": "^4.1.0",
+    "fastify-gql": "5.x.x",
     "pino": "6.x.x",
     "pino-pretty": "4.x.x",
     "pretty-ms": "6.x.x",

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -3,6 +3,7 @@ import fastifyGql from 'fastify-gql';
 import * as Logger from '../helpers/logger';
 import { resolvers } from './resolvers';
 import { schema } from './schema';
+import fastifyCors from 'fastify-cors';
 
 async function startServer(): Promise<void> {
   const logger = Logger.getHttpLogger({
@@ -15,6 +16,7 @@ async function startServer(): Promise<void> {
     resolvers,
     graphiql: 'playground',
   });
+  server.register(fastifyCors);
   await server.listen(3123, '0.0.0.0');
 }
 


### PR DESCRIPTION
We need this so client-side applications can use the GraphQL endpoint directly.