### PR TITLE
Expose dataset identifier rather than IRI

### DIFF
--- a/src/server/resolvers.ts
+++ b/src/server/resolvers.ts
@@ -8,7 +8,7 @@ import {Dataset} from '@netwerk-digitaal-erfgoed/network-of-terms-catalog';
 async function listSources(object: any, args: any, context: any): Promise<any> {
   return context.catalog.datasets.map((dataset: Dataset) => {
     return {
-      identifier: dataset.iri,
+      identifier: dataset.identifier,
       name: dataset.name,
     };
   });


### PR DESCRIPTION
This was the old behaviour, which we should keep for now.

We may later switch to identifiers (#17) but should do so consistently throughout the app.