### PR TITLE
Upgrade network-of-terms-catalog to 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,40 +23,40 @@ This command reads the catalog information in file `configs/catalog.ttl`.
 
 ```bash
 # Cultuurhistorische Thesaurus: query SPARQL endpoint
-bin/run sources:query --distributions https://data.cultureelerfgoed.nl/PoolParty/sparql/term/id/cht --query fiets
+bin/run sources:query --uris https://data.cultureelerfgoed.nl/PoolParty/sparql/term/id/cht --query fiets
 
 # RKDartists: query SPARQL endpoint
-bin/run sources:query --distributions https://data.netwerkdigitaalerfgoed.nl/rkd/rkdartists/sparql --query Gogh
+bin/run sources:query --uris https://data.netwerkdigitaalerfgoed.nl/rkd/rkdartists/sparql --query Gogh
 
 # RKDartists and NTA: query SPARQL endpoints simultaneously
-bin/run sources:query --distributions https://data.netwerkdigitaalerfgoed.nl/rkd/rkdartists/sparql,http://data.bibliotheken.nl/thesp/sparql --query Gogh
+bin/run sources:query --uris https://data.netwerkdigitaalerfgoed.nl/rkd/rkdartists/sparql,http://data.bibliotheken.nl/thesp/sparql --query Gogh
 
 # NTA: query SPARQL endpoint
-bin/run sources:query --distributions http://data.bibliotheken.nl/thesp/sparql --query Wieringa
-bin/run sources:query --distributions http://data.bibliotheken.nl/thesp/sparql --query "'Wier*'"
-bin/run sources:query --distributions http://data.bibliotheken.nl/thesp/sparql --query "Wieringa OR Mulisch"
-bin/run sources:query --distributions http://data.bibliotheken.nl/thesp/sparql --query "Jan AND Vries"
+bin/run sources:query --uris http://data.bibliotheken.nl/thesp/sparql --query Wieringa
+bin/run sources:query --uris http://data.bibliotheken.nl/thesp/sparql --query "'Wier*'"
+bin/run sources:query --uris http://data.bibliotheken.nl/thesp/sparql --query "Wieringa OR Mulisch"
+bin/run sources:query --uris http://data.bibliotheken.nl/thesp/sparql --query "Jan AND Vries"
 
 # NMvW: query SPARQL endpoint
-bin/run sources:query --distributions https://data.netwerkdigitaalerfgoed.nl/NMVW/thesaurus/sparql --query eiland
+bin/run sources:query --uris https://data.netwerkdigitaalerfgoed.nl/NMVW/thesaurus/sparql --query eiland
 
 # AAT: query SPARQL endpoint
-bin/run sources:query --distributions http://vocab.getty.edu/aat/sparql --query schilderij
-bin/run sources:query --distributions http://vocab.getty.edu/aat/sparql --query "schil*"
-bin/run sources:query --distributions http://vocab.getty.edu/aat/sparql --query "schilderij OR tekening"
-bin/run sources:query --distributions http://vocab.getty.edu/aat/sparql --query "cartoon* OR prent*"
+bin/run sources:query --uris http://vocab.getty.edu/aat/sparql --query schilderij
+bin/run sources:query --uris http://vocab.getty.edu/aat/sparql --query "schil*"
+bin/run sources:query --uris http://vocab.getty.edu/aat/sparql --query "schilderij OR tekening"
+bin/run sources:query --uris http://vocab.getty.edu/aat/sparql --query "cartoon* OR prent*"
 
 # Wikidata Entities: query SPARQL endpoint
-bin/run sources:query --distributions https://www.wikidata.org/sparql --query Rembrandt
+bin/run sources:query --uris https://www.wikidata.org/sparql --query Rembrandt
 ```
 
 Add `--loglevel` to the commands to see what's going on underneath. For example:
 
-    bin/run sources:query --distributions https://data.cultureelerfgoed.nl/PoolParty/sparql/term/id/cht --query fiets --loglevel info
+    bin/run sources:query --uris https://data.cultureelerfgoed.nl/PoolParty/sparql/term/id/cht --query fiets --loglevel info
 
 Search results are piped to stdout. Redirect these elsewhere for further analysis. For example:
 
-    bin/run sources:query --distributions https://data.cultureelerfgoed.nl/PoolParty/sparql/term/id/cht --query fiets > cht.txt
+    bin/run sources:query --uris https://data.cultureelerfgoed.nl/PoolParty/sparql/term/id/cht --query fiets > cht.txt
 
 ## Query sources via GraphQL
 

--- a/README.md
+++ b/README.md
@@ -23,40 +23,40 @@ This command reads the catalog information in file `configs/catalog.ttl`.
 
 ```bash
 # Cultuurhistorische Thesaurus: query SPARQL endpoint
-bin/run sources:query --identifiers cht --query fiets
+bin/run sources:query --distributions https://data.cultureelerfgoed.nl/PoolParty/sparql/term/id/cht --query fiets
 
 # RKDartists: query SPARQL endpoint
-bin/run sources:query --identifiers rkdartists --query Gogh
+bin/run sources:query --distributions https://data.netwerkdigitaalerfgoed.nl/rkd/rkdartists/sparql --query Gogh
 
 # RKDartists and NTA: query SPARQL endpoints simultaneously
-bin/run sources:query --identifiers rkdartists,nta --query Gogh
+bin/run sources:query --distributions https://data.netwerkdigitaalerfgoed.nl/rkd/rkdartists/sparql,http://data.bibliotheken.nl/thesp/sparql --query Gogh
 
 # NTA: query SPARQL endpoint
-bin/run sources:query --identifiers nta --query Wieringa
-bin/run sources:query --identifiers nta --query "'Wier*'"
-bin/run sources:query --identifiers nta --query "Wieringa OR Mulisch"
-bin/run sources:query --identifiers nta --query "Jan AND Vries"
+bin/run sources:query --distributions http://data.bibliotheken.nl/thesp/sparql --query Wieringa
+bin/run sources:query --distributions http://data.bibliotheken.nl/thesp/sparql --query "'Wier*'"
+bin/run sources:query --distributions http://data.bibliotheken.nl/thesp/sparql --query "Wieringa OR Mulisch"
+bin/run sources:query --distributions http://data.bibliotheken.nl/thesp/sparql --query "Jan AND Vries"
 
 # NMvW: query SPARQL endpoint
-bin/run sources:query --identifiers nmvw --query eiland
+bin/run sources:query --distributions https://data.netwerkdigitaalerfgoed.nl/NMVW/thesaurus/sparql --query eiland
 
 # AAT: query SPARQL endpoint
-bin/run sources:query --identifiers aat --query schilderij
-bin/run sources:query --identifiers aat --query "schil*"
-bin/run sources:query --identifiers aat --query "schilderij OR tekening"
-bin/run sources:query --identifiers aat --query "cartoon* OR prent*"
+bin/run sources:query --distributions http://vocab.getty.edu/aat/sparql --query schilderij
+bin/run sources:query --distributions http://vocab.getty.edu/aat/sparql --query "schil*"
+bin/run sources:query --distributions http://vocab.getty.edu/aat/sparql --query "schilderij OR tekening"
+bin/run sources:query --distributions http://vocab.getty.edu/aat/sparql --query "cartoon* OR prent*"
 
 # Wikidata Entities: query SPARQL endpoint
-bin/run sources:query --identifiers wikidata-entities --query Rembrandt
+bin/run sources:query --distributions https://www.wikidata.org/sparql --query Rembrandt
 ```
 
 Add `--loglevel` to the commands to see what's going on underneath. For example:
 
-    bin/run sources:query --identifiers cht --query fiets --loglevel info
+    bin/run sources:query --distributions https://data.cultureelerfgoed.nl/PoolParty/sparql/term/id/cht --query fiets --loglevel info
 
 Search results are piped to stdout. Redirect these elsewhere for further analysis. For example:
 
-    bin/run sources:query --identifiers cht --query fiets > cht.txt
+    bin/run sources:query --distributions https://data.cultureelerfgoed.nl/PoolParty/sparql/term/id/cht --query fiets > cht.txt
 
 ## Query sources via GraphQL
 
@@ -74,7 +74,7 @@ http://localhost:3123/playground
 query Sources {
   sources {
     name
-    identifier
+    uri
   }
 }
 ```
@@ -84,9 +84,9 @@ query Sources {
 ```
 # Query Cultuurhistorische Thesaurus (CHT)
 query Terms {
-  terms(sources: ["cht"], query: "fiets") {
+  terms(sources: ["https://data.cultureelerfgoed.nl/PoolParty/sparql/term/id/cht"], query: "fiets") {
     source {
-      identifier
+      uri
       name
     }
     terms {
@@ -103,9 +103,9 @@ query Terms {
 ```
 # Query RKDartists and NTA simultaneously
 query QueryTerms {
-  terms(sources: ["rkdartists", "nta"], query: "Gogh") {
+  terms(sources: ["https://data.netwerkdigitaalerfgoed.nl/rkd/rkdartists/sparql", "http://data.bibliotheken.nl/thesp/sparql"], query: "Gogh") {
     source {
-      identifier
+      uri
       name
     }
     terms {

--- a/package-lock.json
+++ b/package-lock.json
@@ -740,15 +740,15 @@
       "integrity": "sha512-6IK2u3ggJGrV81tq0mj5I4x7OOdRGyOD8a/ZeomRLnaA7byhnT++PqIvEmJm8rm7g1Vt8cbvAxbJ1Jv+7SmFug=="
     },
     "@comunica/actor-rdf-resolve-quad-pattern-sparql-json": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-sparql-json/-/actor-rdf-resolve-quad-pattern-sparql-json-1.14.0.tgz",
-      "integrity": "sha512-X+px6q0M2fIVwwUHtzicu68QBWgbWR+PUfxvL9zxGt5xYVUM3eIhGS97Mae+CfQs5NGG8xEf/bX4rlm5nysyOg==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-sparql-json/-/actor-rdf-resolve-quad-pattern-sparql-json-1.16.0.tgz",
+      "integrity": "sha512-TfeEDKaYCR3NZvOmhaUY49+Z+5vPKRnx3xTA5L1GsvsU4Bc2kdFKI7ax7FR1p3CrM7AHDlxvu8/AzHIAWFbtxg==",
       "requires": {
         "@rdfjs/data-model": "^1.1.1",
         "@types/rdf-js": "^3.0.0",
-        "asynciterator": "^3.0.0",
+        "asynciterator": "^3.0.1",
         "rdf-terms": "^1.4.0",
-        "sparqlalgebrajs": "^2.2.2",
+        "sparqlalgebrajs": "^2.3.2",
         "sparqljson-parse": "^1.5.0"
       },
       "dependencies": {
@@ -761,9 +761,38 @@
           }
         },
         "asynciterator": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/asynciterator/-/asynciterator-3.0.0.tgz",
-          "integrity": "sha512-8aq8lNFDG47H/LlEFHLze17T+zjsHP7yscvEdyWh8MYBEI9CkpBbKuFx6FT4dmMVsBZ0D1LUq8aIh8+vHd/74Q=="
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/asynciterator/-/asynciterator-3.0.1.tgz",
+          "integrity": "sha512-i63IZ/CLbSwT+9+jezA8BFnMmmOylNN+2/yNqMSr37IdzjPLnYMfEvTOFt46hDA+san7k9CZN6gEzCgCTTfAWA=="
+        },
+        "n3": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/n3/-/n3-1.6.2.tgz",
+          "integrity": "sha512-9R45WRNxNPblKLbXGwR9IvtaVvdr80vRxME79fhWnqBzHb2GcP6lS77Mvf8Fx6Wpfn8PpBTdggceWsSMDGY/SA==",
+          "requires": {
+            "queue-microtask": "^1.1.2",
+            "readable-stream": "^3.6.0"
+          }
+        },
+        "sparqlalgebrajs": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.3.2.tgz",
+          "integrity": "sha512-QnjSz25c6ruALbxxD7e9E64hoi/yPMz5MzxUIjLEiTob2zWoM4Pj6GlYZAMnxcCdXXURZO+n0Obt/8XhQj4XiQ==",
+          "requires": {
+            "@rdfjs/data-model": "^1.1.2",
+            "fast-deep-equal": "^3.1.1",
+            "minimist": "^1.2.5",
+            "rdf-string": "^1.3.1",
+            "sparqljs": "^3.1.1"
+          }
+        },
+        "sparqljs": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.1.1.tgz",
+          "integrity": "sha512-HYSwEu++souL4YjJbRx+3dJ1aNYNuR+BbZdPmdrmD4QMSO14J63BEshpcSURcNRsuriOI+05wo2AaxVvpjhgkg==",
+          "requires": {
+            "n3": "^1.6.0"
+          }
         }
       }
     },
@@ -821,10 +850,47 @@
       "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-simple/-/actor-sparql-serialize-simple-1.13.0.tgz",
       "integrity": "sha512-VBmtD1PvWhQfxnhQAvyi9WmC+1Mhk2fQWR4pctFxZAml8dzudjrxA2lF1T65fusLB4dpQ770b/g7LsRw0QANFg=="
     },
+    "@comunica/actor-sparql-serialize-sparql-csv": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-csv/-/actor-sparql-serialize-sparql-csv-1.16.0.tgz",
+      "integrity": "sha512-unsuwwpuXdf+mqnrlFws/XpywRCPMjXccXZo2ORNlV4/iuWB3pIToAW0dnhTNxXafpWKiN/lcX05xQitH6jm3Q==",
+      "requires": {
+        "@types/rdf-js": "^3.0.0"
+      },
+      "dependencies": {
+        "@types/rdf-js": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@types/rdf-js/-/rdf-js-3.0.3.tgz",
+          "integrity": "sha512-1dvodNHh/YpLovHA/b046Nu+xERVt0KcYJFQH1A8S4ZcMj+stYtx4ypXw0X2/oatbREUo4JW+cjoBll3CVtwSQ==",
+          "requires": {
+            "@types/node": "*"
+          }
+        }
+      }
+    },
     "@comunica/actor-sparql-serialize-sparql-json": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-json/-/actor-sparql-serialize-sparql-json-1.13.0.tgz",
       "integrity": "sha512-d4DR5fdIRiDhvYZteN7riytEeHEd9JdemlMA7S7nYpSr3l32b/8AYwcBIdbNYqNbPAtBXdZ7d7MxQakycA0XLw=="
+    },
+    "@comunica/actor-sparql-serialize-sparql-tsv": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-tsv/-/actor-sparql-serialize-sparql-tsv-1.16.0.tgz",
+      "integrity": "sha512-GX6ELMgGa3ztPZC2jKQ6/xyYf+fg4p/6p/ww/GzrSplEpmRlKFQIgUCu735ZKM3w5lZdxf8IDzOeVqDARI8jhw==",
+      "requires": {
+        "@types/rdf-js": "^3.0.0",
+        "rdf-string-ttl": "^1.0.1"
+      },
+      "dependencies": {
+        "@types/rdf-js": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@types/rdf-js/-/rdf-js-3.0.3.tgz",
+          "integrity": "sha512-1dvodNHh/YpLovHA/b046Nu+xERVt0KcYJFQH1A8S4ZcMj+stYtx4ypXw0X2/oatbREUo4JW+cjoBll3CVtwSQ==",
+          "requires": {
+            "@types/node": "*"
+          }
+        }
+      }
     },
     "@comunica/actor-sparql-serialize-sparql-xml": {
       "version": "1.13.0",
@@ -1125,9 +1191,9 @@
       }
     },
     "@netwerk-digitaal-erfgoed/network-of-terms-catalog": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@netwerk-digitaal-erfgoed/network-of-terms-catalog/-/network-of-terms-catalog-1.0.1.tgz",
-      "integrity": "sha512-m4nxGQXuoajnTyZNVYDumuOVctg8EAFx0E57NdC0XT/1vwvRUykTJTCkbqr/yfe+tE91+gtXoexv5Nu76cIxww==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@netwerk-digitaal-erfgoed/network-of-terms-catalog/-/network-of-terms-catalog-2.0.0.tgz",
+      "integrity": "sha512-lJEsGCRB4IoJGbAgpLyKGZ0psxEuccgXcOZgHSfsxq4J+SKF4FpsEvhs9mdtLKFzmOK7GipikcHEI2a3xqbeGQ==",
       "requires": {
         "@comunica/actor-init-sparql": "^1.14.0",
         "@comunica/actor-init-sparql-rdfjs": "^1.14.0",
@@ -1138,39 +1204,35 @@
       },
       "dependencies": {
         "@comunica/actor-abstract-bindings-hash": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-bindings-hash/-/actor-abstract-bindings-hash-1.14.0.tgz",
-          "integrity": "sha512-dOsaJyDtxa8Pg+JYOOKgTHFqyv7UWwqS5wBTVeJb/3249STUgQ/I9BX8JnDsCyNbyCjOnzONQhkO2Mc36Fnz1Q==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-bindings-hash/-/actor-abstract-bindings-hash-1.16.0.tgz",
+          "integrity": "sha512-W7oU8J0n6wC8R8EQ7UEvdmaJXf/Z3gEVCw9H+WXJSTEg1B77nrHuQs1lJreteKCIJEhC7BQYLtrfKE5N92edKw==",
           "requires": {
             "canonicalize": "^1.0.1",
             "rdf-string": "^1.4.2"
           }
         },
         "@comunica/actor-abstract-mediatyped": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-1.14.0.tgz",
-          "integrity": "sha512-mQh3aBRB78TioV0pBuWxalJatc7qI1kk92vyMe5ADO7+zknzfUTMZQK702j79smZdaYuzmPi5JQwPgFy7V/tMQ==",
-          "requires": {
-            "@types/lodash.mapvalues": "^4.6.3",
-            "lodash.mapvalues": "^4.6.0"
-          }
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-1.15.0.tgz",
+          "integrity": "sha512-rB0DnIuiZKGqAd6JmcXdajmgDPWzffqCqLyAp2A967NRN1NlPbPnfwkCJBHVehdcyT69dAaEkHoHDZpbwOVjHg=="
         },
         "@comunica/actor-abstract-path": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-1.14.0.tgz",
-          "integrity": "sha512-NLIIXTFxWw/j1Olg84tYDP8+wkmHzIwSImXtQ2eKqMDTg1XAhPQ6yEXiuLsD9mEBwViQFchBaaCGdF2XyNGEqg==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-1.16.0.tgz",
+          "integrity": "sha512-a53X/a9DTl6rYNbBGXCmUY9crusU6ySAiRZY3usiPWzqHeiZonM5+eRKzYm8vazxg3hLBs8jowKiZhiUPrx4wQ==",
           "requires": {
             "@rdfjs/data-model": "^1.1.1",
             "@types/rdf-js": "^3.0.0",
-            "asynciterator": "^3.0.0",
+            "asynciterator": "^3.0.1",
             "rdf-string": "^1.4.2",
-            "sparqlalgebrajs": "^2.2.2"
+            "sparqlalgebrajs": "^2.3.2"
           }
         },
         "@comunica/actor-http-memento": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-http-memento/-/actor-http-memento-1.14.0.tgz",
-          "integrity": "sha512-UREA2jPckRCnskknoIJRlSK6wwLgNL+rYEME6pSRWZKWNOCK8XYBnEvHaLFYDvWwptrNdkKneOVlR7qu1oVDJg==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-http-memento/-/actor-http-memento-1.16.0.tgz",
+          "integrity": "sha512-X58EUsxFch+/VoS58Ld1yFsSNjeu7xYtvPV6x4IpGv16V+QJot4KyKH25+SAwNOQDiRxShX55FovCCVvSxK35w==",
           "requires": {
             "@types/parse-link-header": "^1.0.0",
             "cross-fetch": "^3.0.5",
@@ -1178,9 +1240,9 @@
           }
         },
         "@comunica/actor-http-native": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-http-native/-/actor-http-native-1.14.0.tgz",
-          "integrity": "sha512-RHWCNQd/7En8gdfOYSFtb0X+YTBvf8DgeJOq8Qbge5rNuYo+PUxVm0ClgPh544jhh5tAS+ZjySAecQDJSkk1rQ==",
+          "version": "1.16.2",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-http-native/-/actor-http-native-1.16.2.tgz",
+          "integrity": "sha512-KhmYTKOmf4QZwd8CVy4f4o6d/LVzBy19JmpOIP1vLcOTAVOXg6KXDT+NEVSoDIc9T5fpKDh91bWuukptUqVjig==",
           "requires": {
             "@types/parse-link-header": "^1.0.0",
             "cross-fetch": "^3.0.5",
@@ -1189,119 +1251,122 @@
           }
         },
         "@comunica/actor-http-proxy": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-1.14.0.tgz",
-          "integrity": "sha512-sVwk7SfIvk29LEQ7KuhmlU0MzbinJN8Ll6JZvbSeHELWAuKqb/Pb5s+paxQTT7zDMlbghh/M/+jEeZyOvks/3w=="
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-1.16.0.tgz",
+          "integrity": "sha512-5aD5y9b6DvcCX2/ud/aVvUjvipppMmzKRV3C0evbA3NoAZ4VF8ejD+JpIjDsrvrbWeXVPueXvL/yfssUz17iIg=="
         },
         "@comunica/actor-init-sparql": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql/-/actor-init-sparql-1.14.0.tgz",
-          "integrity": "sha512-8Wc2OrzYjIt3Q7Mk90ewN/DLxvfNi7FAgiuj1UXvsuv0/2nlnDGmfjxGjXT9yJcZzmD1eFJ/PydAmRY3yJbp9A==",
+          "version": "1.16.2",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql/-/actor-init-sparql-1.16.2.tgz",
+          "integrity": "sha512-jzE/sW1ciNXtO/tRYEhSiKFxpB9/cqPME9a2jq/GYq9PmTv5MzcUbZEY7x8QRkRQ3Dp0Z2JHI/sorps8LPwcmQ==",
           "requires": {
-            "@comunica/actor-abstract-bindings-hash": "^1.14.0",
-            "@comunica/actor-abstract-mediatyped": "^1.14.0",
-            "@comunica/actor-http-memento": "^1.14.0",
-            "@comunica/actor-http-native": "^1.14.0",
-            "@comunica/actor-http-proxy": "^1.14.0",
-            "@comunica/actor-optimize-query-operation-join-bgp": "^1.14.0",
-            "@comunica/actor-query-operation-ask": "^1.14.0",
-            "@comunica/actor-query-operation-bgp-empty": "^1.14.0",
-            "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.14.0",
-            "@comunica/actor-query-operation-bgp-single": "^1.14.0",
-            "@comunica/actor-query-operation-construct": "^1.14.0",
-            "@comunica/actor-query-operation-describe-subject": "^1.14.0",
-            "@comunica/actor-query-operation-distinct-hash": "^1.14.0",
-            "@comunica/actor-query-operation-extend": "^1.14.0",
-            "@comunica/actor-query-operation-filter-sparqlee": "^1.14.0",
-            "@comunica/actor-query-operation-from-quad": "^1.14.0",
-            "@comunica/actor-query-operation-group": "^1.14.0",
-            "@comunica/actor-query-operation-join": "^1.14.0",
-            "@comunica/actor-query-operation-leftjoin-left-deep": "^1.14.0",
-            "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.14.0",
-            "@comunica/actor-query-operation-minus": "^1.14.0",
-            "@comunica/actor-query-operation-orderby-sparqlee": "^1.14.0",
-            "@comunica/actor-query-operation-path-alt": "^1.14.0",
-            "@comunica/actor-query-operation-path-inv": "^1.14.0",
-            "@comunica/actor-query-operation-path-link": "^1.14.0",
-            "@comunica/actor-query-operation-path-nps": "^1.14.0",
-            "@comunica/actor-query-operation-path-one-or-more": "^1.14.0",
-            "@comunica/actor-query-operation-path-seq": "^1.14.0",
-            "@comunica/actor-query-operation-path-zero-or-more": "^1.14.0",
-            "@comunica/actor-query-operation-path-zero-or-one": "^1.14.0",
-            "@comunica/actor-query-operation-project": "^1.14.0",
-            "@comunica/actor-query-operation-quadpattern": "^1.14.0",
-            "@comunica/actor-query-operation-reduced-hash": "^1.14.0",
-            "@comunica/actor-query-operation-service": "^1.14.0",
-            "@comunica/actor-query-operation-slice": "^1.14.0",
-            "@comunica/actor-query-operation-sparql-endpoint": "^1.14.0",
-            "@comunica/actor-query-operation-union": "^1.14.0",
-            "@comunica/actor-query-operation-values": "^1.14.0",
-            "@comunica/actor-rdf-dereference-http-parse": "^1.14.0",
-            "@comunica/actor-rdf-join-multi-smallest": "^1.14.0",
-            "@comunica/actor-rdf-join-symmetrichash": "^1.14.0",
-            "@comunica/actor-rdf-metadata-all": "^1.14.0",
-            "@comunica/actor-rdf-metadata-extract-hydra-controls": "^1.14.0",
-            "@comunica/actor-rdf-metadata-extract-hydra-count": "^1.14.0",
-            "@comunica/actor-rdf-metadata-extract-sparql-service": "^1.14.0",
-            "@comunica/actor-rdf-metadata-primary-topic": "^1.14.0",
-            "@comunica/actor-rdf-parse-html": "^1.14.0",
-            "@comunica/actor-rdf-parse-html-rdfa": "^1.14.0",
-            "@comunica/actor-rdf-parse-html-script": "^1.14.0",
-            "@comunica/actor-rdf-parse-jsonld": "^1.14.0",
-            "@comunica/actor-rdf-parse-n3": "^1.14.0",
-            "@comunica/actor-rdf-parse-rdfxml": "^1.14.0",
-            "@comunica/actor-rdf-parse-xml-rdfa": "^1.14.0",
-            "@comunica/actor-rdf-resolve-hypermedia-links-next": "^1.14.0",
-            "@comunica/actor-rdf-resolve-hypermedia-none": "^1.14.0",
-            "@comunica/actor-rdf-resolve-hypermedia-qpf": "^1.14.0",
-            "@comunica/actor-rdf-resolve-hypermedia-sparql": "^1.14.0",
-            "@comunica/actor-rdf-resolve-quad-pattern-federated": "^1.14.0",
-            "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": "^1.14.0",
-            "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.14.0",
-            "@comunica/actor-rdf-serialize-jsonld": "^1.14.0",
-            "@comunica/actor-rdf-serialize-n3": "^1.14.0",
-            "@comunica/actor-sparql-parse-algebra": "^1.14.0",
-            "@comunica/actor-sparql-parse-graphql": "^1.14.0",
-            "@comunica/actor-sparql-serialize-json": "^1.14.0",
-            "@comunica/actor-sparql-serialize-rdf": "^1.14.0",
-            "@comunica/actor-sparql-serialize-simple": "^1.14.0",
-            "@comunica/actor-sparql-serialize-sparql-json": "^1.14.0",
-            "@comunica/actor-sparql-serialize-sparql-xml": "^1.14.0",
-            "@comunica/actor-sparql-serialize-stats": "^1.14.0",
-            "@comunica/actor-sparql-serialize-table": "^1.14.0",
-            "@comunica/actor-sparql-serialize-tree": "^1.14.0",
-            "@comunica/bus-context-preprocess": "^1.14.0",
-            "@comunica/bus-http": "^1.14.0",
-            "@comunica/bus-http-invalidate": "^1.14.0",
-            "@comunica/bus-init": "^1.14.0",
-            "@comunica/bus-optimize-query-operation": "^1.14.0",
-            "@comunica/bus-query-operation": "^1.14.0",
-            "@comunica/bus-rdf-dereference": "^1.14.0",
-            "@comunica/bus-rdf-dereference-paged": "^1.14.0",
-            "@comunica/bus-rdf-join": "^1.14.0",
-            "@comunica/bus-rdf-metadata": "^1.14.0",
-            "@comunica/bus-rdf-metadata-extract": "^1.14.0",
-            "@comunica/bus-rdf-parse": "^1.14.0",
-            "@comunica/bus-rdf-parse-html": "^1.14.0",
-            "@comunica/bus-rdf-resolve-hypermedia": "^1.14.0",
-            "@comunica/bus-rdf-resolve-hypermedia-links": "^1.14.0",
-            "@comunica/bus-rdf-resolve-quad-pattern": "^1.14.0",
-            "@comunica/bus-rdf-serialize": "^1.14.0",
-            "@comunica/bus-sparql-parse": "^1.14.0",
-            "@comunica/bus-sparql-serialize": "^1.14.0",
-            "@comunica/core": "^1.14.0",
-            "@comunica/logger-pretty": "^1.14.0",
-            "@comunica/logger-void": "^1.14.0",
-            "@comunica/mediator-all": "^1.14.0",
-            "@comunica/mediator-combine-pipeline": "^1.14.0",
-            "@comunica/mediator-combine-union": "^1.14.0",
-            "@comunica/mediator-number": "^1.14.0",
-            "@comunica/mediator-race": "^1.14.0",
-            "@comunica/runner": "^1.14.0",
-            "@comunica/runner-cli": "^1.14.0",
+            "@comunica/actor-abstract-bindings-hash": "^1.16.0",
+            "@comunica/actor-abstract-mediatyped": "^1.15.0",
+            "@comunica/actor-http-memento": "^1.16.0",
+            "@comunica/actor-http-native": "^1.16.2",
+            "@comunica/actor-http-proxy": "^1.16.0",
+            "@comunica/actor-optimize-query-operation-join-bgp": "^1.16.0",
+            "@comunica/actor-query-operation-ask": "^1.16.0",
+            "@comunica/actor-query-operation-bgp-empty": "^1.16.0",
+            "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.16.0",
+            "@comunica/actor-query-operation-bgp-single": "^1.16.0",
+            "@comunica/actor-query-operation-construct": "^1.16.0",
+            "@comunica/actor-query-operation-describe-subject": "^1.16.0",
+            "@comunica/actor-query-operation-distinct-hash": "^1.16.0",
+            "@comunica/actor-query-operation-extend": "^1.16.0",
+            "@comunica/actor-query-operation-filter-sparqlee": "^1.16.0",
+            "@comunica/actor-query-operation-from-quad": "^1.16.0",
+            "@comunica/actor-query-operation-group": "^1.16.0",
+            "@comunica/actor-query-operation-join": "^1.16.0",
+            "@comunica/actor-query-operation-leftjoin-left-deep": "^1.16.0",
+            "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.16.0",
+            "@comunica/actor-query-operation-minus": "^1.16.0",
+            "@comunica/actor-query-operation-orderby-sparqlee": "^1.16.0",
+            "@comunica/actor-query-operation-path-alt": "^1.16.0",
+            "@comunica/actor-query-operation-path-inv": "^1.16.0",
+            "@comunica/actor-query-operation-path-link": "^1.16.0",
+            "@comunica/actor-query-operation-path-nps": "^1.16.0",
+            "@comunica/actor-query-operation-path-one-or-more": "^1.16.0",
+            "@comunica/actor-query-operation-path-seq": "^1.16.0",
+            "@comunica/actor-query-operation-path-zero-or-more": "^1.16.0",
+            "@comunica/actor-query-operation-path-zero-or-one": "^1.16.0",
+            "@comunica/actor-query-operation-project": "^1.16.0",
+            "@comunica/actor-query-operation-quadpattern": "^1.16.0",
+            "@comunica/actor-query-operation-reduced-hash": "^1.16.0",
+            "@comunica/actor-query-operation-service": "^1.16.0",
+            "@comunica/actor-query-operation-slice": "^1.16.0",
+            "@comunica/actor-query-operation-sparql-endpoint": "^1.16.0",
+            "@comunica/actor-query-operation-union": "^1.16.0",
+            "@comunica/actor-query-operation-values": "^1.16.0",
+            "@comunica/actor-rdf-dereference-http-parse": "^1.16.0",
+            "@comunica/actor-rdf-join-multi-smallest": "^1.16.0",
+            "@comunica/actor-rdf-join-nestedloop": "^1.16.0",
+            "@comunica/actor-rdf-join-symmetrichash": "^1.16.0",
+            "@comunica/actor-rdf-metadata-all": "^1.15.0",
+            "@comunica/actor-rdf-metadata-extract-hydra-controls": "^1.15.0",
+            "@comunica/actor-rdf-metadata-extract-hydra-count": "^1.15.0",
+            "@comunica/actor-rdf-metadata-extract-sparql-service": "^1.15.0",
+            "@comunica/actor-rdf-metadata-primary-topic": "^1.15.0",
+            "@comunica/actor-rdf-parse-html": "^1.15.0",
+            "@comunica/actor-rdf-parse-html-rdfa": "^1.15.0",
+            "@comunica/actor-rdf-parse-html-script": "^1.16.1",
+            "@comunica/actor-rdf-parse-jsonld": "^1.16.0",
+            "@comunica/actor-rdf-parse-n3": "^1.15.0",
+            "@comunica/actor-rdf-parse-rdfxml": "^1.15.0",
+            "@comunica/actor-rdf-parse-xml-rdfa": "^1.15.0",
+            "@comunica/actor-rdf-resolve-hypermedia-links-next": "^1.15.0",
+            "@comunica/actor-rdf-resolve-hypermedia-none": "^1.15.0",
+            "@comunica/actor-rdf-resolve-hypermedia-qpf": "^1.16.0",
+            "@comunica/actor-rdf-resolve-hypermedia-sparql": "^1.16.0",
+            "@comunica/actor-rdf-resolve-quad-pattern-federated": "^1.16.0",
+            "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": "^1.16.0",
+            "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.16.0",
+            "@comunica/actor-rdf-serialize-jsonld": "^1.15.0",
+            "@comunica/actor-rdf-serialize-n3": "^1.15.0",
+            "@comunica/actor-sparql-parse-algebra": "^1.16.0",
+            "@comunica/actor-sparql-parse-graphql": "^1.15.0",
+            "@comunica/actor-sparql-serialize-json": "^1.16.0",
+            "@comunica/actor-sparql-serialize-rdf": "^1.16.0",
+            "@comunica/actor-sparql-serialize-simple": "^1.16.0",
+            "@comunica/actor-sparql-serialize-sparql-csv": "^1.16.0",
+            "@comunica/actor-sparql-serialize-sparql-json": "^1.16.0",
+            "@comunica/actor-sparql-serialize-sparql-tsv": "^1.16.0",
+            "@comunica/actor-sparql-serialize-sparql-xml": "^1.16.0",
+            "@comunica/actor-sparql-serialize-stats": "^1.16.0",
+            "@comunica/actor-sparql-serialize-table": "^1.16.0",
+            "@comunica/actor-sparql-serialize-tree": "^1.16.0",
+            "@comunica/bus-context-preprocess": "^1.15.0",
+            "@comunica/bus-http": "^1.16.0",
+            "@comunica/bus-http-invalidate": "^1.15.0",
+            "@comunica/bus-init": "^1.15.0",
+            "@comunica/bus-optimize-query-operation": "^1.16.0",
+            "@comunica/bus-query-operation": "^1.16.0",
+            "@comunica/bus-rdf-dereference": "^1.15.0",
+            "@comunica/bus-rdf-dereference-paged": "^1.15.0",
+            "@comunica/bus-rdf-join": "^1.16.0",
+            "@comunica/bus-rdf-metadata": "^1.15.0",
+            "@comunica/bus-rdf-metadata-extract": "^1.15.0",
+            "@comunica/bus-rdf-parse": "^1.15.0",
+            "@comunica/bus-rdf-parse-html": "^1.15.0",
+            "@comunica/bus-rdf-resolve-hypermedia": "^1.15.0",
+            "@comunica/bus-rdf-resolve-hypermedia-links": "^1.15.0",
+            "@comunica/bus-rdf-resolve-quad-pattern": "^1.16.0",
+            "@comunica/bus-rdf-serialize": "^1.15.0",
+            "@comunica/bus-sparql-parse": "^1.15.0",
+            "@comunica/bus-sparql-serialize": "^1.16.0",
+            "@comunica/core": "^1.15.0",
+            "@comunica/logger-pretty": "^1.15.0",
+            "@comunica/logger-void": "^1.15.0",
+            "@comunica/mediator-all": "^1.15.0",
+            "@comunica/mediator-combine-pipeline": "^1.15.0",
+            "@comunica/mediator-combine-union": "^1.15.0",
+            "@comunica/mediator-number": "^1.15.0",
+            "@comunica/mediator-race": "^1.15.0",
+            "@comunica/runner": "^1.16.0",
+            "@comunica/runner-cli": "^1.16.0",
             "@types/minimist": "^1.2.0",
             "@types/rdf-js": "^3.0.0",
-            "asynciterator": "^3.0.0",
+            "asynciterator": "^3.0.1",
             "asyncreiterable": "^2.0.0",
             "minimist": "^1.2.0",
             "negotiate": "^1.0.1",
@@ -1312,474 +1377,465 @@
           }
         },
         "@comunica/actor-init-sparql-rdfjs": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql-rdfjs/-/actor-init-sparql-rdfjs-1.14.0.tgz",
-          "integrity": "sha512-r4iV96KNvCALvNA52O3tGy1R83VCJmVkLTA5AuEqXmyJJNCeeK5Af4KcO7BULOL20FYgFw1wrfpSVb50PMzqXQ==",
+          "version": "1.16.2",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql-rdfjs/-/actor-init-sparql-rdfjs-1.16.2.tgz",
+          "integrity": "sha512-37FizXW2XCtyRFq0vjCqTAzxnVVklYGoq3Rmn6sBelF6wKW7pqtHunBA3yOJfo5MKRVoFD04wHCbwaWC6xaYEw==",
           "requires": {
-            "@comunica/actor-abstract-mediatyped": "^1.14.0",
-            "@comunica/actor-init-sparql": "^1.14.0",
-            "@comunica/actor-query-operation-ask": "^1.14.0",
-            "@comunica/actor-query-operation-bgp-empty": "^1.14.0",
-            "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.14.0",
-            "@comunica/actor-query-operation-bgp-single": "^1.14.0",
-            "@comunica/actor-query-operation-construct": "^1.14.0",
-            "@comunica/actor-query-operation-describe-subject": "^1.14.0",
-            "@comunica/actor-query-operation-distinct-hash": "^1.14.0",
-            "@comunica/actor-query-operation-extend": "^1.14.0",
-            "@comunica/actor-query-operation-filter-sparqlee": "^1.14.0",
-            "@comunica/actor-query-operation-from-quad": "^1.14.0",
-            "@comunica/actor-query-operation-join": "^1.14.0",
-            "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.14.0",
-            "@comunica/actor-query-operation-orderby-sparqlee": "^1.14.0",
-            "@comunica/actor-query-operation-path-alt": "^1.14.0",
-            "@comunica/actor-query-operation-path-inv": "^1.14.0",
-            "@comunica/actor-query-operation-path-link": "^1.14.0",
-            "@comunica/actor-query-operation-path-nps": "^1.14.0",
-            "@comunica/actor-query-operation-path-one-or-more": "^1.14.0",
-            "@comunica/actor-query-operation-path-seq": "^1.14.0",
-            "@comunica/actor-query-operation-path-zero-or-more": "^1.14.0",
-            "@comunica/actor-query-operation-path-zero-or-one": "^1.14.0",
-            "@comunica/actor-query-operation-project": "^1.14.0",
-            "@comunica/actor-query-operation-quadpattern": "^1.14.0",
-            "@comunica/actor-query-operation-service": "^1.14.0",
-            "@comunica/actor-query-operation-slice": "^1.14.0",
-            "@comunica/actor-query-operation-union": "^1.14.0",
-            "@comunica/actor-query-operation-values": "^1.14.0",
-            "@comunica/actor-rdf-join-nestedloop": "^1.14.0",
-            "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.14.0",
-            "@comunica/actor-rdf-serialize-jsonld": "^1.14.0",
-            "@comunica/actor-rdf-serialize-n3": "^1.14.0",
-            "@comunica/actor-sparql-parse-algebra": "^1.14.0",
-            "@comunica/actor-sparql-serialize-json": "^1.14.0",
-            "@comunica/actor-sparql-serialize-rdf": "^1.14.0",
-            "@comunica/actor-sparql-serialize-simple": "^1.14.0",
-            "@comunica/actor-sparql-serialize-sparql-json": "^1.14.0",
-            "@comunica/actor-sparql-serialize-sparql-xml": "^1.14.0",
-            "@comunica/bus-context-preprocess": "^1.14.0",
-            "@comunica/bus-init": "^1.14.0",
-            "@comunica/bus-query-operation": "^1.14.0",
-            "@comunica/bus-rdf-join": "^1.14.0",
-            "@comunica/bus-rdf-resolve-quad-pattern": "^1.14.0",
-            "@comunica/bus-rdf-serialize": "^1.14.0",
-            "@comunica/bus-sparql-parse": "^1.14.0",
-            "@comunica/bus-sparql-serialize": "^1.14.0",
-            "@comunica/core": "^1.14.0",
-            "@comunica/mediator-combine-pipeline": "^1.14.0",
-            "@comunica/mediator-combine-union": "^1.14.0",
-            "@comunica/mediator-number": "^1.14.0",
-            "@comunica/mediator-race": "^1.14.0",
-            "@comunica/runner": "^1.14.0",
-            "@comunica/runner-cli": "^1.14.0"
+            "@comunica/actor-abstract-mediatyped": "^1.15.0",
+            "@comunica/actor-init-sparql": "^1.16.2",
+            "@comunica/actor-query-operation-ask": "^1.16.0",
+            "@comunica/actor-query-operation-bgp-empty": "^1.16.0",
+            "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.16.0",
+            "@comunica/actor-query-operation-bgp-single": "^1.16.0",
+            "@comunica/actor-query-operation-construct": "^1.16.0",
+            "@comunica/actor-query-operation-describe-subject": "^1.16.0",
+            "@comunica/actor-query-operation-distinct-hash": "^1.16.0",
+            "@comunica/actor-query-operation-extend": "^1.16.0",
+            "@comunica/actor-query-operation-filter-sparqlee": "^1.16.0",
+            "@comunica/actor-query-operation-from-quad": "^1.16.0",
+            "@comunica/actor-query-operation-join": "^1.16.0",
+            "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.16.0",
+            "@comunica/actor-query-operation-orderby-sparqlee": "^1.16.0",
+            "@comunica/actor-query-operation-path-alt": "^1.16.0",
+            "@comunica/actor-query-operation-path-inv": "^1.16.0",
+            "@comunica/actor-query-operation-path-link": "^1.16.0",
+            "@comunica/actor-query-operation-path-nps": "^1.16.0",
+            "@comunica/actor-query-operation-path-one-or-more": "^1.16.0",
+            "@comunica/actor-query-operation-path-seq": "^1.16.0",
+            "@comunica/actor-query-operation-path-zero-or-more": "^1.16.0",
+            "@comunica/actor-query-operation-path-zero-or-one": "^1.16.0",
+            "@comunica/actor-query-operation-project": "^1.16.0",
+            "@comunica/actor-query-operation-quadpattern": "^1.16.0",
+            "@comunica/actor-query-operation-service": "^1.16.0",
+            "@comunica/actor-query-operation-slice": "^1.16.0",
+            "@comunica/actor-query-operation-union": "^1.16.0",
+            "@comunica/actor-query-operation-values": "^1.16.0",
+            "@comunica/actor-rdf-join-nestedloop": "^1.16.0",
+            "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.16.0",
+            "@comunica/actor-rdf-serialize-jsonld": "^1.15.0",
+            "@comunica/actor-rdf-serialize-n3": "^1.15.0",
+            "@comunica/actor-sparql-parse-algebra": "^1.16.0",
+            "@comunica/actor-sparql-serialize-json": "^1.16.0",
+            "@comunica/actor-sparql-serialize-rdf": "^1.16.0",
+            "@comunica/actor-sparql-serialize-simple": "^1.16.0",
+            "@comunica/actor-sparql-serialize-sparql-json": "^1.16.0",
+            "@comunica/actor-sparql-serialize-sparql-xml": "^1.16.0",
+            "@comunica/bus-context-preprocess": "^1.15.0",
+            "@comunica/bus-init": "^1.15.0",
+            "@comunica/bus-query-operation": "^1.16.0",
+            "@comunica/bus-rdf-join": "^1.16.0",
+            "@comunica/bus-rdf-resolve-quad-pattern": "^1.16.0",
+            "@comunica/bus-rdf-serialize": "^1.15.0",
+            "@comunica/bus-sparql-parse": "^1.15.0",
+            "@comunica/bus-sparql-serialize": "^1.16.0",
+            "@comunica/core": "^1.15.0",
+            "@comunica/mediator-combine-pipeline": "^1.15.0",
+            "@comunica/mediator-combine-union": "^1.15.0",
+            "@comunica/mediator-number": "^1.15.0",
+            "@comunica/mediator-race": "^1.15.0",
+            "@comunica/runner": "^1.16.0",
+            "@comunica/runner-cli": "^1.16.0"
           }
         },
         "@comunica/actor-optimize-query-operation-join-bgp": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-1.14.0.tgz",
-          "integrity": "sha512-rVElyg++Jd7hhAdzKC8rgVDnGjtPTcRr8GyKvjIjC/ue/JI9GDz0LDP4448Y63MFd87TKYDnSS78KtmbS94YYA==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-1.16.0.tgz",
+          "integrity": "sha512-KWuAKG8S+IwonyecNjqrO5dlSKSVmR1cxP117/DEUPIltXl0IY2W3Q/HKRRZ+DXwV/LRMExIXILdUkZgYUSnAw==",
           "requires": {
-            "sparqlalgebrajs": "^2.2.2"
+            "sparqlalgebrajs": "^2.3.2"
           }
         },
         "@comunica/actor-query-operation-ask": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-1.14.0.tgz",
-          "integrity": "sha512-y0QcS7Fl+TAdlYzRUemSCfblulLnBNPfMEK24p+ABs2yXXetZEbaPGvv0L1iDqSeWfEvsjIzCMx021f5UUtM1A=="
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-1.16.0.tgz",
+          "integrity": "sha512-zlWYPh7GoIw7epzcORfDWwRFsfLciJGVSaCR2C46AZj8CctApf+mzrRDY7H3WSETyTc6s9T1fiDzGjBY/P3TbA=="
         },
         "@comunica/actor-query-operation-bgp-empty": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-empty/-/actor-query-operation-bgp-empty-1.14.0.tgz",
-          "integrity": "sha512-9kW2sn3aRgB5Aty7zb1IcSxXC9l9gicNnXrZSDHOIISkKXForACLy5OyffEZF6n/PSSzLLHBb92Jv6pF+HCYrA==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-empty/-/actor-query-operation-bgp-empty-1.16.0.tgz",
+          "integrity": "sha512-C8q0YKNcIbMZ1KWL1juCoTbppYQcI3/0qlp/boBD1w8yeNVt2ytxB0cKsdVilvLVVcooISJJKNn4j8uGqOJsZg==",
           "requires": {
-            "asynciterator": "^3.0.0",
+            "asynciterator": "^3.0.1",
             "rdf-string": "^1.4.2",
             "rdf-terms": "^1.4.0"
           }
         },
         "@comunica/actor-query-operation-bgp-left-deep-smallest": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-left-deep-smallest/-/actor-query-operation-bgp-left-deep-smallest-1.14.0.tgz",
-          "integrity": "sha512-G47D9HFkRQId3f2zmtf0fJAmBLLff3cspF2MCTpvulhV1jmgDFBymTz9XUjk7q6eHosh9It1xLsxE8TciOWYCw==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-left-deep-smallest/-/actor-query-operation-bgp-left-deep-smallest-1.16.0.tgz",
+          "integrity": "sha512-8zB8ajT7z6nYDge9//7zP0sziKmnCFLVVtqqyacSQ8Yu9jl15b42rqMiZ0ty9c3qZncH2DagqiTd/5VCJP3nMg==",
           "requires": {
-            "@types/lodash.uniq": "^4.5.3",
             "@types/rdf-js": "^3.0.0",
-            "asynciterator": "^3.0.0",
-            "lodash.uniq": "^4.5.0",
+            "asynciterator": "^3.0.1",
             "rdf-string": "^1.4.2",
             "rdf-terms": "^1.4.0"
           }
         },
         "@comunica/actor-query-operation-bgp-single": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-single/-/actor-query-operation-bgp-single-1.14.0.tgz",
-          "integrity": "sha512-Z86s0MgOC+h6Md/wyytwVlYXfGbynZIYqNFqOmbnJMFLwJMZ9xJWU2yXxKuFj5dIl1URntRPBkmP5eKNJ27IhA=="
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-single/-/actor-query-operation-bgp-single-1.16.0.tgz",
+          "integrity": "sha512-nUcGlq9uJCl5O7rGnFCrFeHrWSRD7hZW9QU+B7tCoSbJoUrKS9hBKkDO6xUHmsmztRKfzHgMO9LFDvmc5jGKlQ=="
         },
         "@comunica/actor-query-operation-construct": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-1.14.0.tgz",
-          "integrity": "sha512-FsFx6Vz56xtVg5tTqin96++1RSrIzzcMrLf9vMOnYFo2OtTt/fu3nB5d0bDswu8phvoOyCUyM5TwJbrBg8bwAA==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-1.16.0.tgz",
+          "integrity": "sha512-c4tLLcl7T1JYCg790LEu9Ijn3c7i2yd2uKJ9E2oytx6KLeW0YQeEaiLZ1hn3XDlQHMvfYeGznd4Y+X8632+Faw==",
           "requires": {
             "@rdfjs/data-model": "^1.1.1",
             "@types/rdf-js": "^3.0.0",
-            "asynciterator": "^3.0.0",
+            "asynciterator": "^3.0.1",
             "rdf-terms": "^1.4.0"
           }
         },
         "@comunica/actor-query-operation-describe-subject": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-describe-subject/-/actor-query-operation-describe-subject-1.14.0.tgz",
-          "integrity": "sha512-DGv/zC/o6ChOnBFg9Pidsv+Y5W9LIRMnnpZTo5hW3hDLYdmBfRpF99KdWnCVCDuUjWN7ixK3w97cokiCe3G6Rw==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-describe-subject/-/actor-query-operation-describe-subject-1.16.0.tgz",
+          "integrity": "sha512-F5x0AU/7K9Zw6o5/y2AWsX5G3YPyLoDekWm1bHyztnHD21WFGsOgAt7R3XOJLU4/d9Mc2TpDOj17bttplJRXSg==",
           "requires": {
-            "@comunica/actor-query-operation-union": "^1.14.0",
+            "@comunica/actor-query-operation-union": "^1.16.0",
             "@rdfjs/data-model": "^1.1.1",
             "@types/rdf-js": "^3.0.0",
-            "asynciterator": "^3.0.0"
+            "asynciterator": "^3.0.1"
           }
         },
         "@comunica/actor-query-operation-distinct-hash": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-distinct-hash/-/actor-query-operation-distinct-hash-1.14.0.tgz",
-          "integrity": "sha512-vz521ZtESOJtZp8NCUj1K9feFGOaETTkS4GPz+i77CBZxOvDffVj6wDVDgGxxiqaCMpPEvF/0M2Y7Bjve+0evQ==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-distinct-hash/-/actor-query-operation-distinct-hash-1.16.0.tgz",
+          "integrity": "sha512-/SKXl7lFUlJ83yL81lD3RyzqkV5ONqUiqR8d1D0Vob/m8DI7ynDp8f5x74ocBLdrhFADJvGlVl8703AjJzcD6w==",
           "requires": {
-            "@comunica/actor-abstract-bindings-hash": "^1.14.0"
+            "@comunica/actor-abstract-bindings-hash": "^1.16.0"
           }
         },
         "@comunica/actor-query-operation-extend": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-1.14.0.tgz",
-          "integrity": "sha512-qmfaQKF4ZrtOyTigi4/8b4s8ci0kiwdEZnVlBp30/lx88OpiKL+DIquvxx57ZNX1NZxLQU5f+EmtNvgn2PvNcQ==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-1.16.0.tgz",
+          "integrity": "sha512-xad5NhPZ4KJsk3DTlG6mb0ZEX6LccCRjhFEVZsNT4qr1DPTqD5MaeE/SfjFADCwDniy5gZTxn6AQnQ1LsC52Eg==",
           "requires": {
-            "sparqlee": "^1.4.0"
+            "sparqlee": "^1.4.3"
           }
         },
         "@comunica/actor-query-operation-filter-sparqlee": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-filter-sparqlee/-/actor-query-operation-filter-sparqlee-1.14.0.tgz",
-          "integrity": "sha512-+r+bBkCsMvZqllsZwdhuP3bIvQSUdhNJbdEETx912zBKoHiTdzZ9IB4bsN7Qm8DT083V7fnNWwplTV7YjagRow==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-filter-sparqlee/-/actor-query-operation-filter-sparqlee-1.16.0.tgz",
+          "integrity": "sha512-96ttlUQkBpkiUlXnClvjEaYHtEL8gCVzhOMcMLxuOAifwgv7I6Qe5WQT8QZkJbXbbwNvelXYC4Cs37p85nHSCw==",
           "requires": {
-            "sparqlee": "^1.4.0"
+            "sparqlee": "^1.4.3"
           }
         },
         "@comunica/actor-query-operation-from-quad": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-1.14.0.tgz",
-          "integrity": "sha512-iRsXBkqCHN9gNhAMY8HFE9JU/FiwehzMh5MzNEjaQxzqC2UAUJ+AjgwHi2Ht0Uv0cezb5VKp1V2hIpxQ1wZazg==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-1.16.0.tgz",
+          "integrity": "sha512-qyjSrxmi0WSlxMbZo2djOfUD+2Jkm7s4JOW36ua8JBbSuGAbHwFI3xYSWiWYmLCMQEp3YgqHrTKWeGDSnqxnJQ==",
           "requires": {
-            "@types/lodash.find": "^4.6.3",
             "@types/rdf-js": "^3.0.0",
-            "lodash.find": "^4.6.0",
-            "sparqlalgebrajs": "^2.2.2"
+            "sparqlalgebrajs": "^2.3.2"
           }
         },
         "@comunica/actor-query-operation-group": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-group/-/actor-query-operation-group-1.14.0.tgz",
-          "integrity": "sha512-Efe63RXqhAyFLaPO14r9hwH78Od6zYJUI2inzmll4ImvnWlwrQibEQgp7C5DbFELt+s17NJqv2BbdeAaDSO2fg==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-group/-/actor-query-operation-group-1.16.0.tgz",
+          "integrity": "sha512-xwmoNsfjcsS04s3lLlf6dua81ywFNqOU77g61tZEveCAKyC5fN6rQZM8eLBa87z7HhHLHF42V1TVXh3PD46HaA==",
           "requires": {
-            "@comunica/actor-abstract-bindings-hash": "^1.14.0",
+            "@comunica/actor-abstract-bindings-hash": "^1.16.0",
             "rdf-string": "^1.4.2",
-            "sparqlee": "^1.4.0"
+            "sparqlee": "^1.4.3"
           }
         },
         "@comunica/actor-query-operation-join": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-join/-/actor-query-operation-join-1.14.0.tgz",
-          "integrity": "sha512-KPNBpXgspA8dCGUZF8BqLe2U2QaWw3e+HeOuqvBXPZVeXcXbrl9BMfgo9269RjdsT5QkWrmSk0BIZ2Ds+uKEAw=="
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-join/-/actor-query-operation-join-1.16.0.tgz",
+          "integrity": "sha512-3lJt1dTrBm4ogRwCyEPwqOrJ/QfEEYu5tHUClpiP3vG0L1tmN+wRfewAxU7P8o0Rec0QkqICAMRf252tM0ftgw=="
         },
         "@comunica/actor-query-operation-leftjoin-left-deep": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin-left-deep/-/actor-query-operation-leftjoin-left-deep-1.14.0.tgz",
-          "integrity": "sha512-9pFqobP4xNA3c8hLNsMoEMb/gGRxteRYnZGZHa9+A3HWjQIp4EJjcBnBj/l9ibdfwKR0PJjLlUJ7rlnaPr+BsA==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin-left-deep/-/actor-query-operation-leftjoin-left-deep-1.16.0.tgz",
+          "integrity": "sha512-fVVdcMEFvQpU8eKQyDys7q6jL6SosHdSs2j5ARPmXvY/hzl68coIb4D0JmMIIWmk87TDcc9VUH0mcnHI5f7Eqw==",
           "requires": {
             "@types/rdf-js": "^3.0.0",
-            "asynciterator": "^3.0.0"
+            "asynciterator": "^3.0.1"
           }
         },
         "@comunica/actor-query-operation-leftjoin-nestedloop": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin-nestedloop/-/actor-query-operation-leftjoin-nestedloop-1.14.0.tgz",
-          "integrity": "sha512-N/MPV9aHUoyZ599tedKA1u3q3GakwoNyP4cSkU50ixYH9kKfuQoy1fqUyOIhtwB8reBMBfxxAWXOptOlwf0+Zw==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin-nestedloop/-/actor-query-operation-leftjoin-nestedloop-1.16.0.tgz",
+          "integrity": "sha512-dTNcGe4LTwgJcvAV2TZA9lF6gmvtcQDFm+4UEiY5ehtgOD/Quh39AixYSXTNOsmMmGBamr5iBfk1ABgRwAmzyg==",
           "requires": {
-            "sparqlee": "^1.4.0"
+            "sparqlee": "^1.4.3"
           }
         },
         "@comunica/actor-query-operation-minus": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-1.14.0.tgz",
-          "integrity": "sha512-/Q0C1dB1IK3zuBFTiMbmiT01AW5hBmVEIT8sDsIPRtNIkf9nFekscEl1EeWlRfl5RbToJcjfr0QK9F9UGe/ZBw==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-1.16.0.tgz",
+          "integrity": "sha512-PeM5FouB+BJMU2QYB//SK9O5LCdielQnrr+nTWXyznrx1kpBqMX7Elzmim5huhKY3Y0WfotL6rGsE5DEjdRE1w==",
           "requires": {
-            "@comunica/actor-abstract-bindings-hash": "^1.14.0",
+            "@comunica/actor-abstract-bindings-hash": "^1.16.0",
             "@types/rdf-js": "^3.0.0",
-            "asynciterator": "^3.0.0"
+            "asynciterator": "^3.0.1"
           }
         },
         "@comunica/actor-query-operation-orderby-sparqlee": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-orderby-sparqlee/-/actor-query-operation-orderby-sparqlee-1.14.0.tgz",
-          "integrity": "sha512-Yi0HkbhhB38Lz8cH13iTQQGu5lQo1/hrxWXKQIQzmYmf39XbNKuH6MEWzknhv2RffTHtelY/ZRsedI9Qd4sA9g==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-orderby-sparqlee/-/actor-query-operation-orderby-sparqlee-1.16.0.tgz",
+          "integrity": "sha512-mRubrkxjevfsrr3sMn/scVg9pveNDLammx5jtrBDm5IKkL2muTH6HGduLCmT/zONBkxUZy2uOiXQgxHXrtznsw==",
           "requires": {
             "@types/rdf-js": "^3.0.0",
             "rdf-string": "^1.4.2",
-            "sparqlee": "^1.4.0"
+            "sparqlee": "^1.4.3"
           }
         },
         "@comunica/actor-query-operation-path-alt": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-1.14.0.tgz",
-          "integrity": "sha512-JNzT+vVsfyrwZ48mIBGLsFiRvB1+6SOa5cDlD5U40FzN/Bet1o+ZN5u+FUEVr77PEOTb6x7RIGawf10VdmZJTw==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-1.16.0.tgz",
+          "integrity": "sha512-VJiGYoupy41Rcbbf4BymERWC5U7OjVtSe0JuSkHoOmKl9HcXQo+dGur+XJpbKz391rDY+BB2djH3Bht1YmrYig==",
           "requires": {
-            "@comunica/actor-abstract-path": "^1.14.0",
-            "@types/lodash.uniq": "^4.5.3",
-            "asynciterator": "^3.0.0",
-            "lodash.uniq": "^4.5.0",
-            "sparqlalgebrajs": "^2.2.2"
+            "@comunica/actor-abstract-path": "^1.16.0",
+            "asynciterator": "^3.0.1",
+            "sparqlalgebrajs": "^2.3.2"
           }
         },
         "@comunica/actor-query-operation-path-inv": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-1.14.0.tgz",
-          "integrity": "sha512-KZoTQN9z8JSqk9yqz5O5l5yaWGfoMeXjmFjkTuBVrH30vrtsNmWEVZGe8sjiXk47MHgGlmv2NzYk5TrKcbWkbw==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-1.16.0.tgz",
+          "integrity": "sha512-xVWLGiaIbuv2vudAFVgotHx/YCNQ+deflpgSyg5RsUU7cnqj3njkt4Iq8lX+8Sdwjmr10UIAqXPVMHKsRCRKzA==",
           "requires": {
-            "@comunica/actor-abstract-path": "^1.14.0"
+            "@comunica/actor-abstract-path": "^1.16.0"
           }
         },
         "@comunica/actor-query-operation-path-link": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-1.14.0.tgz",
-          "integrity": "sha512-qtX7eHoHneo+W+vcmMWWALoaNbJHmTXT3lnmaEHETc6+mg9WE8dBlCGth3qQMgBHprnij8iiubdc0MCXduADIg==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-1.16.0.tgz",
+          "integrity": "sha512-YCPgTQGfQCtp88OneFYTyXBG9pHuHs5Plfmj3BZP0fhbIXhn6ywn4LP5NXaVukJFCDwCFRWL9Pd1aZ5N0p9tNQ==",
           "requires": {
-            "@comunica/actor-abstract-path": "^1.14.0",
-            "sparqlalgebrajs": "^2.2.2"
+            "@comunica/actor-abstract-path": "^1.16.0",
+            "sparqlalgebrajs": "^2.3.2"
           }
         },
         "@comunica/actor-query-operation-path-nps": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-1.14.0.tgz",
-          "integrity": "sha512-M+9tDKyE1WZOES8NShRyNk5pTUJA7c6OM6Tu/E725jcxy55O3lb/IjlHE5YoW/6K3MVPuq93f82PS0powW0rjA==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-1.16.0.tgz",
+          "integrity": "sha512-S/CDgtnLQC+3qndBOST1y+AvUsCc/nh08+4s91K9RqkuQwV5/1Sl5B0aThMItazTKuUPj04ujH+PCOArt1+sbQ==",
           "requires": {
-            "@comunica/actor-abstract-path": "^1.14.0",
+            "@comunica/actor-abstract-path": "^1.16.0",
             "rdf-string": "^1.4.2",
-            "sparqlalgebrajs": "^2.2.2"
+            "sparqlalgebrajs": "^2.3.2"
           }
         },
         "@comunica/actor-query-operation-path-one-or-more": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-1.14.0.tgz",
-          "integrity": "sha512-O/6o2zTQXX8UUS1ngKXcxUflydl/URHn2oWUq9Rrst3f5Y4Mv/4LNTiZ8JcyezEsnGt9t8cLfut3hQvw2766ag==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-1.16.0.tgz",
+          "integrity": "sha512-RpjvSeua4hsSISonfK53qMlWizQ9ou208zpiGpGLamDAVpLj4pgKAQ3ksfWM+GR2sXVDiCIAvpszJkSEa9NY/w==",
           "requires": {
-            "@comunica/actor-abstract-path": "^1.14.0",
+            "@comunica/actor-abstract-path": "^1.16.0",
             "@types/rdf-js": "^3.0.0",
-            "asynciterator": "^3.0.0",
+            "asynciterator": "^3.0.1",
             "rdf-string": "^1.4.2",
-            "sparqlalgebrajs": "^2.2.2"
+            "sparqlalgebrajs": "^2.3.2"
           }
         },
         "@comunica/actor-query-operation-path-seq": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-1.14.0.tgz",
-          "integrity": "sha512-vFHgDAOzdgOY/YDrqiZRI/qzyARXREiG9BXNJ9z1aiCSxM9KiTTeCCfIRM7U3bpvTky7weeyUineytgSssn1Dw==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-1.16.0.tgz",
+          "integrity": "sha512-/vbN8Y8a+Sb1XcP796YxwahiD2b3euxHBu1h4pLu0oTKg6KTqbjHjbGQhxe95sWU3HKoH7F7VErTjlX8Wl29Kw==",
           "requires": {
-            "@comunica/actor-abstract-path": "^1.14.0",
+            "@comunica/actor-abstract-path": "^1.16.0",
             "rdf-string": "^1.4.2",
-            "sparqlalgebrajs": "^2.2.2"
+            "sparqlalgebrajs": "^2.3.2"
           }
         },
         "@comunica/actor-query-operation-path-zero-or-more": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-1.14.0.tgz",
-          "integrity": "sha512-ngmRKS2TvkrzjY8YNwOM7GxyvCqpzmASCnI0A2FQJxh1dt0eBthgGqdsbLKZ9cqnH66FS0BzeLovH6CXLER0KQ==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-1.16.0.tgz",
+          "integrity": "sha512-Z5NhpB4MEZHk3yhInOHILWiNzK+ZGWr+HvjYD5PtDHtbWWgE3nrxbuNhdXs1iXgaJsZWlp7ziE+H3ms4GcYjUQ==",
           "requires": {
-            "@comunica/actor-abstract-path": "^1.14.0",
+            "@comunica/actor-abstract-path": "^1.16.0",
             "rdf-string": "^1.4.2",
-            "sparqlalgebrajs": "^2.2.2"
+            "sparqlalgebrajs": "^2.3.2"
           }
         },
         "@comunica/actor-query-operation-path-zero-or-one": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-1.14.0.tgz",
-          "integrity": "sha512-NXANUuub71OqoEzwie1VLZ5qsQyrxFWbF0iEOobdpDLI8qdpfyihBxVDdALaFcRgAxqPysIrwOzFUWS8DelN+w==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-1.16.0.tgz",
+          "integrity": "sha512-pGzrXcXsm6l0RKF9SfC8njqw72XiOns/chiuKegChqTQd00DubTJVHmfb2HUuNyiNVJ2BrjwYdAysP1gI93D5w==",
           "requires": {
-            "@comunica/actor-abstract-path": "^1.14.0",
-            "asynciterator": "^3.0.0",
+            "@comunica/actor-abstract-path": "^1.16.0",
+            "asynciterator": "^3.0.1",
             "rdf-string": "^1.4.2"
           }
         },
         "@comunica/actor-query-operation-project": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-project/-/actor-query-operation-project-1.14.0.tgz",
-          "integrity": "sha512-lNFQdOmFUG0EmMh9q6Smp9F9R71YDyAOnXJHG8/sQui5FKP4SmTO31qluDUOFVoVCwFVKiHt3MN8HLIjTAhdpA==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-project/-/actor-query-operation-project-1.16.0.tgz",
+          "integrity": "sha512-uTi+GmB04RnZ7Sw3XJst8tmPtiqLmT1Z4+zTspTgnWwndeWzdw7w7v6apCZDoivvPLi1Jq/7hGNn6+3FsIGp+A==",
           "requires": {
             "@comunica/data-factory": "^1.14.0",
             "rdf-string": "^1.4.2"
           }
         },
         "@comunica/actor-query-operation-quadpattern": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-quadpattern/-/actor-query-operation-quadpattern-1.14.0.tgz",
-          "integrity": "sha512-E/OQqrF/uyjEHWFXIUlpr62wOmKZ21JBOonG05oudG+jWteh1KiDMkHegq5nDzh8Nt0AnN3/bSJX4GY8fRhN7A==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-quadpattern/-/actor-query-operation-quadpattern-1.16.0.tgz",
+          "integrity": "sha512-QFml3MgYd5nmnsPHoDvOcx/StY+4L0ix5C1q5h8jagwIbcuRSfo1Ay0gLMlbEDuZkzrHhkN9o6OsSMTVuXsiEQ==",
           "requires": {
             "@types/rdf-js": "^3.0.0",
-            "asynciterator": "^3.0.0",
+            "asynciterator": "^3.0.1",
             "rdf-string": "^1.4.2",
             "rdf-terms": "^1.4.0"
           }
         },
         "@comunica/actor-query-operation-reduced-hash": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-1.14.0.tgz",
-          "integrity": "sha512-Qsfw9cv0OYRAQ7BgC03Un7KIHKsSDQCas000AToHoYI+YBzxRYo7TXRHZKoP2u672kqeYPwv7NpW6STwa9ETDQ==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-1.16.0.tgz",
+          "integrity": "sha512-zE1K+d6HBhGsvQQd/XGYUgpue/aSKeHbdB2r+yzEels0ShPYxogVV69aHQAUxPXvz+kbPEzqwTWz5a28lJW+cw==",
           "requires": {
-            "@comunica/actor-abstract-bindings-hash": "^1.14.0",
+            "@comunica/actor-abstract-bindings-hash": "^1.16.0",
             "@types/lru-cache": "^5.1.0",
             "lru-cache": "^6.0.0"
           }
         },
         "@comunica/actor-query-operation-service": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-service/-/actor-query-operation-service-1.14.0.tgz",
-          "integrity": "sha512-GriB5p7TMeqXieJ6qhK54pvrVMb39yv1XbPdftTULBfYPSudVXTPAq/V4bcYuqdmqTw0wlshvqir8z0qoLVH/w==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-service/-/actor-query-operation-service-1.16.0.tgz",
+          "integrity": "sha512-UTWmUZa59o6DaPqHjtFM8CES3/vlis6psAW5Wt4Bw+5sgK2XZ1EWFNM/BbQG5m0OetzgDJS+BRVbsJNDGdHRdw==",
           "requires": {
-            "asynciterator": "^3.0.0"
+            "asynciterator": "^3.0.1"
           }
         },
         "@comunica/actor-query-operation-slice": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-1.14.0.tgz",
-          "integrity": "sha512-mw4P4BKu4J3ay+kalLuZuULZ+uPXgd5NFNil7MSadgBEj1qASXiEfty6JdjEwKAdlXYe9OPLsum1+MxzzlNQWA=="
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-1.16.0.tgz",
+          "integrity": "sha512-vFo1HVlz+0Jz2a8ppPU4tXPbSL/G9TILPSyvSJjXpQpvOQRih7m9AFeXUjGtJ6sFo5SryAkgynfk6jO0Co9tzw=="
         },
         "@comunica/actor-query-operation-sparql-endpoint": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-sparql-endpoint/-/actor-query-operation-sparql-endpoint-1.14.0.tgz",
-          "integrity": "sha512-X/K/PgQWNSrRyyOjE4gCtFdQsAjbdpQ1niZKVxwMrO+BSpIbH0r3MPVJX7UJO1freZPn32qiDrHcY1W2DKQIbw==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-sparql-endpoint/-/actor-query-operation-sparql-endpoint-1.16.0.tgz",
+          "integrity": "sha512-3VxGRHjwWBP23ezSKVgFJG5/nj5pMhX++8d3w3WFCC5kss+p7Qnq9P06sz/42Ya/hY/CGJM4iramadGOTnbEmw==",
           "requires": {
-            "@comunica/utils-datasource": "^1.14.0",
+            "@comunica/utils-datasource": "^1.16.0",
             "@types/rdf-js": "^3.0.0",
             "arrayify-stream": "^1.0.0",
-            "asynciterator": "^3.0.0",
+            "asynciterator": "^3.0.1",
             "fetch-sparql-endpoint": "^1.6.0",
             "rdf-string": "^1.4.2",
             "rdf-terms": "^1.4.0",
-            "sparqlalgebrajs": "^2.2.2"
+            "sparqlalgebrajs": "^2.3.2"
           }
         },
         "@comunica/actor-query-operation-union": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-union/-/actor-query-operation-union-1.14.0.tgz",
-          "integrity": "sha512-PMOop9IJao3wN9T/8Lb0oiU1CYHfHuPxA0p+8Ej+AFVxkLxiX/bgOi5JXJf5PJ8ux0SoAqqo7w6+lGwmuINfLw==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-union/-/actor-query-operation-union-1.16.0.tgz",
+          "integrity": "sha512-x3eZA7T004Pdf+rEMj5ts7qs66+FFBddKnWdT10fRDkXoRTTStoSsw2oW/fk8Il9FcEAQVtNXur7ehVvzV5S5A==",
           "requires": {
-            "@types/lodash.union": "^4.6.3",
-            "asynciterator": "^3.0.0",
-            "lodash.union": "^4.6.0"
+            "asynciterator": "^3.0.1"
           }
         },
         "@comunica/actor-query-operation-values": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-values/-/actor-query-operation-values-1.14.0.tgz",
-          "integrity": "sha512-X73xcHzhC2p5NTNMs7GDykPxrXv4RxzJGUXlBsfkXx3dHaLYsaSPScuJe5JI7FZN9wXLyuB5xZxoMvQttj4KTA==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-values/-/actor-query-operation-values-1.16.0.tgz",
+          "integrity": "sha512-X2KE3DNiKtK1sjLkakDgfTZs2paMgNu54zp6wAlIWzg5QVj+iDk+XM5wx8JFI+Mrro4oRN9Gl9TOjGupNjLnxQ==",
           "requires": {
-            "asynciterator": "^3.0.0",
+            "asynciterator": "^3.0.1",
             "rdf-string": "^1.4.2"
           }
         },
         "@comunica/actor-rdf-dereference-http-parse": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-http-parse/-/actor-rdf-dereference-http-parse-1.14.0.tgz",
-          "integrity": "sha512-bj+8tJr6ZgXPdLuYrjr4MuOxQL1yX8uQbO9JVKvfTJE+ntvFPGAhUu3y4hFoXTj0bepf6RprKE8GIW+PdxaVDw==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-http-parse/-/actor-rdf-dereference-http-parse-1.16.0.tgz",
+          "integrity": "sha512-IKSw5jjQLIDkbd7eX3Sw0oMuPBujQ4JX6UMpDA846T4lOZcUBTovp0PPKL4zyUd88Ea9a84Qn6uREOWed4nKvg==",
           "requires": {
+            "cross-fetch": "^3.0.5",
             "relative-to-absolute-iri": "^1.0.5"
           }
         },
         "@comunica/actor-rdf-join-multi-smallest": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-multi-smallest/-/actor-rdf-join-multi-smallest-1.14.0.tgz",
-          "integrity": "sha512-wONddiP1bDFpa5m5x1euQSnBbwhWrMnH5gpqxeSZKb0e7yEy+8+JnGPXnPFA9gJnsYtICUlf9pzofmhOk6WZuA=="
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-multi-smallest/-/actor-rdf-join-multi-smallest-1.16.0.tgz",
+          "integrity": "sha512-03oN4MqKBP0eVtMPyJT/PrYR7znDXU37E6sHqW/VGqws5A+myz4G/mxSSOjVE6csN5bt2wNrfpzv9J7hjmHyVA=="
         },
         "@comunica/actor-rdf-join-nestedloop": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-nestedloop/-/actor-rdf-join-nestedloop-1.14.0.tgz",
-          "integrity": "sha512-rGcj6jaN/4kYl6UHdSc0bWDG0pESTE04VYkrwZhg3aFdRAv9X+94ejGDVXrQrG5Pa6goraGLNJpS8pNb7H/epA==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-nestedloop/-/actor-rdf-join-nestedloop-1.16.0.tgz",
+          "integrity": "sha512-f+2x4hgMGWkIroGc9ld3o/dFKZIgvV5DVRI9AGsJR+AZaDmet7nydKs8fw/6nEjMfYIvuNlGVgmSEsLgsAa7sA==",
           "requires": {
-            "asyncjoin": "^1.0.0"
+            "asyncjoin": "^1.0.1"
           }
         },
         "@comunica/actor-rdf-join-symmetrichash": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-symmetrichash/-/actor-rdf-join-symmetrichash-1.14.0.tgz",
-          "integrity": "sha512-5Y9N7tIN2WgHP6DTW0sJTYHokzxZiCS4h7Nvb3I5nXlHzFNTi2/FlsqYE6gVKpcjaPgGdDD2OjSqTqplJZLfhw==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-symmetrichash/-/actor-rdf-join-symmetrichash-1.16.0.tgz",
+          "integrity": "sha512-d1Sszprnc+aJQt1cjycroGAkhAa2fMyECelcJGqwKWpVAXT/nsbOB0Ixb0eKTF4uGlYFrdA/OSG7frwdAORepg==",
           "requires": {
-            "asyncjoin": "^1.0.0"
+            "asyncjoin": "^1.0.1"
           }
         },
         "@comunica/actor-rdf-metadata-all": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-all/-/actor-rdf-metadata-all-1.14.0.tgz",
-          "integrity": "sha512-o7ZsJevHcHr26ZNdedPbGeXCFQha+55LBZz6CdTMIcvDmezqhAec5LxcMCwW4z6TNJeQ3xCr/HSFkXT5YIA+RQ==",
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-all/-/actor-rdf-metadata-all-1.15.0.tgz",
+          "integrity": "sha512-Ax+q0igPmDQeriFL4hDMQWQPV4tsTzyboqnuXqj9U84YXmJ3y+5a5Wh/35odR3W31SwMrs56jYNIpZBKwx0+RA==",
           "requires": {
             "@types/rdf-js": "^3.0.0"
           }
         },
         "@comunica/actor-rdf-metadata-extract-hydra-controls": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-controls/-/actor-rdf-metadata-extract-hydra-controls-1.14.0.tgz",
-          "integrity": "sha512-9vm4iZ3+llkoF3vwn4CSTMR8RR87k0JyNWao0hMoZFW8GxvU1gxWhjVezJm9x/H7FT1E9L+xVZZ4jKDnOwNZ8Q==",
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-controls/-/actor-rdf-metadata-extract-hydra-controls-1.15.0.tgz",
+          "integrity": "sha512-Ih5OJQGfmJe5ihMeFwtWhWKSCxLXEKID3i3NGm8MgiFFbEzLAAf1YLLIK57cW88vahY+3YkPZ7tq3FeIeAi3tw==",
           "requires": {
-            "@types/lodash.assign": "^4.2.3",
             "@types/rdf-js": "^3.0.0",
             "@types/uritemplate": "^0.3.4",
-            "lodash.assign": "^4.2.0",
             "uritemplate": "0.3.4"
           }
         },
         "@comunica/actor-rdf-metadata-extract-hydra-count": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-count/-/actor-rdf-metadata-extract-hydra-count-1.14.0.tgz",
-          "integrity": "sha512-G8bU6u4n9dytjpvo8z2LjyxhKCwuo9WyZfhWNl8zv3ouayBia1vkNBPE/mirHwNPYxAwUai2BGNxRwzpUHnsnA=="
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-count/-/actor-rdf-metadata-extract-hydra-count-1.15.0.tgz",
+          "integrity": "sha512-3qNJWsSo0xR8xt7MEFD7rVlQXiBTLddzUK/5lX1A4dB3jk20a+c62WltctWYiIFtyCs0qYluAJ8xuJ2ItOlP7w=="
         },
         "@comunica/actor-rdf-metadata-extract-sparql-service": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-sparql-service/-/actor-rdf-metadata-extract-sparql-service-1.14.0.tgz",
-          "integrity": "sha512-pJW49X1dyEvi5rv1B6tEhpbrB1A7h9sGJOpAr4+bHJ52+BptEzwVspeF06bMnAC+5fHFtjBKHiZFOyYfKUpM1Q==",
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-sparql-service/-/actor-rdf-metadata-extract-sparql-service-1.15.0.tgz",
+          "integrity": "sha512-CCikTWHa8nNUfmDHPGjgTH60XGcOJtkckzZXdk6kG4rMKXocsj86/cwzYM89P58LOMKy4IFfsSpoEqKIhn2gog==",
           "requires": {
             "relative-to-absolute-iri": "^1.0.5"
           }
         },
         "@comunica/actor-rdf-metadata-primary-topic": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-primary-topic/-/actor-rdf-metadata-primary-topic-1.14.0.tgz",
-          "integrity": "sha512-2nnW8KjNd3j1fwH/pcTlqqkDr4RgLrJZuEAUBAp8odhHcBKb445cJGaSQB8KS6rWm0L9igMt5R8hqIg49hfHKA==",
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-primary-topic/-/actor-rdf-metadata-primary-topic-1.15.0.tgz",
+          "integrity": "sha512-7YRtw2us52nXYcaPyk8q/rCopioCS5LEVDEteD3RqCd7KMVhg+VZYU0iD5cMF9tyYr8NoXdm1/CYxTnSZE/LNg==",
           "requires": {
             "@types/rdf-js": "^3.0.0"
           }
         },
         "@comunica/actor-rdf-parse-html": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-1.14.0.tgz",
-          "integrity": "sha512-ovYZpTfPVIfYFI2WeJYPuvBUHNmm5dozAKV/XHs1B4wTBf80E+ckx4GiTEIsonKjaMclsFZL494bc0DU6glrIQ==",
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-1.15.0.tgz",
+          "integrity": "sha512-eC43jtLqY3wfA6aRim83l+3NfoMQCZv/lPP2MvqxY04/Rk77DdqKtKS2GfYrIBc8aqDOoreVgiBQG5TzPzm5Ew==",
           "requires": {
             "@types/rdf-js": "^3.0.0",
             "htmlparser2": "^4.0.0"
           }
         },
         "@comunica/actor-rdf-parse-html-rdfa": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-1.14.0.tgz",
-          "integrity": "sha512-L6k8x1ZjtdkB36l+VmJB/78ZoB3igtkT8AEXh68rX2lEVbfp2uI2WC0P3sKPe5esAzz3p20wxyjq1eXefiji/Q==",
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-1.15.0.tgz",
+          "integrity": "sha512-1rA7YCjY1v7/1oRKzthVw633HZmHux96SQW5j+FIJTvX4GoBvf1seS082HY7WQGRpZVgLxOUxtAOQcp7zT4dHA==",
           "requires": {
             "rdfa-streaming-parser": "^1.1.1"
           }
         },
         "@comunica/actor-rdf-parse-html-script": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-1.14.0.tgz",
-          "integrity": "sha512-YBw8k2Ym4EMBacRnomWcSgVlFv2hBMKFHoQn/hVs8gQZGrEexPOuVqEWbQPcOz+9GeAJY+uQGlEKF1knR4tASA==",
+          "version": "1.16.1",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-1.16.1.tgz",
+          "integrity": "sha512-IYagk0RzIQEzj/78KvoICDgOiPnwvj44S/PH2ha++o9Se0FgTxRjHrWTluETiczOcvrV54TeVh0YDYJck+xz/w==",
           "requires": {
             "@types/rdf-js": "^3.0.0",
             "relative-to-absolute-iri": "^1.0.5"
           }
         },
         "@comunica/actor-rdf-parse-jsonld": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-1.14.0.tgz",
-          "integrity": "sha512-FzbGmdM9SITBna4yY3kioc5JnTZL3y1Obdgby/qXIC8Oy8TRTL2/d/Dv+lrkoG5xtz6mVjEaqqWtx7IRF3L0Tg==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-1.16.0.tgz",
+          "integrity": "sha512-LtAIv75bhHe2teN0vjWZ6EkjwnK6Yw56Q1ZuxgrWZLGrbdRF6YZuXglW+IqWeZ45tIUqhweS83k17/9fR3UK5w==",
           "requires": {
             "@types/rdf-js": "^3.0.0",
             "jsonld-streaming-parser": "^2.0.2",
@@ -1787,117 +1843,116 @@
           }
         },
         "@comunica/actor-rdf-parse-n3": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-1.14.0.tgz",
-          "integrity": "sha512-uk+MQgFCdOBHKp8cUUj0hOrI/ZGL/5oOmV2jNH6OSb6XXLvpcqgqzanpUDKmXlQZ7TB5LBcZHUVPj1OH38a7qA==",
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-1.15.0.tgz",
+          "integrity": "sha512-YWk7XSDN8GDOFL+u5PtadZmIUzAh5ZUYB/LwXLENeymIgWEaSvJo5H4QqdGmnJFArlgXX2Thk8jTvbtubiNTvw==",
           "requires": {
             "@types/n3": "^1.4.2",
             "n3": "^1.0.0"
           }
         },
         "@comunica/actor-rdf-parse-rdfxml": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-1.14.0.tgz",
-          "integrity": "sha512-zUEZlYBF3AYqbkBzKj5wRkenF9ZFj/GWkHFiiq2E52o0vwFRRt/6OK3EZ1vDZR1g6NB+uJ49LbkDQrcO39YkBA==",
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-1.15.0.tgz",
+          "integrity": "sha512-Rec0dnaTW95Mx91cfQPBkDkgEhoFd9J36FtiJAotLFPOiXp4YsTEZGQNSODTbhchfaTS6HDTFnETQ6GbmutaCQ==",
           "requires": {
             "rdfxml-streaming-parser": "^1.1.0"
           }
         },
         "@comunica/actor-rdf-parse-xml-rdfa": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-1.14.0.tgz",
-          "integrity": "sha512-j6heFYc1+bOHMQkKpqFFSSXoveTM3ch/0WLbQsy4MQfAKR2Y7VjY90GPq6vnYReDzZ7hpb4Til0LZmfIuxp0iA==",
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-1.15.0.tgz",
+          "integrity": "sha512-34CI/f/JQTEfrnxyqB7Y+EhkhW0tTMsHoC8yu+Y6AtSVdj2FYkSR+GmAk9F65JVnm/RC9uh1T7yT5yJMVvmgiQ==",
           "requires": {
             "rdfa-streaming-parser": "^1.1.1"
           }
         },
         "@comunica/actor-rdf-resolve-hypermedia-links-next": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-links-next/-/actor-rdf-resolve-hypermedia-links-next-1.14.0.tgz",
-          "integrity": "sha512-GUUrCK0CbV2Aege1/cijMZuzeNbuhw4/mnux9J4Txv57EAMHJQZc6prAYM9K+MoxhQOTZAppnTAr9jx1cshlNg=="
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-links-next/-/actor-rdf-resolve-hypermedia-links-next-1.15.0.tgz",
+          "integrity": "sha512-TgQurH1G50rdgnQ9WCWchYrUDMk+379oVuha5JISwW5Dc33/wVjR+hoIkrAfKx/kIi7846mcEHO4qNQ5V818hw=="
         },
         "@comunica/actor-rdf-resolve-hypermedia-none": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-none/-/actor-rdf-resolve-hypermedia-none-1.14.0.tgz",
-          "integrity": "sha512-HPVvV27KScvl+6wxCi4FRiHmq1a5ey827P8Q9N6Kuzzqaz94c8AkF6fnQbOl13fZk21a5e8adZhKiIxOtRhT5w==",
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-none/-/actor-rdf-resolve-hypermedia-none-1.15.0.tgz",
+          "integrity": "sha512-dgCFXKbmY9UKSaczpmdVFeSNNcotgWJavC979HQO40zjq6tg3kRDT82M0ucjuDB7fIglzA8xQYTvbjIWYNrm4g==",
           "requires": {
             "@types/rdf-js": "^3.0.0",
             "rdf-store-stream": "^1.0.1"
           }
         },
         "@comunica/actor-rdf-resolve-hypermedia-qpf": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-qpf/-/actor-rdf-resolve-hypermedia-qpf-1.14.0.tgz",
-          "integrity": "sha512-qD6bWQTjF5VvASrWVDKihChknPUeGbHwloxzAR/4wxrHualiYKtnCH0027agkUWMphlhUn1G5KDv10LcrIHrDg==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-qpf/-/actor-rdf-resolve-hypermedia-qpf-1.16.0.tgz",
+          "integrity": "sha512-ikOdP68hwoG9jFqe7ezpOfvWirXtFmKjCvbWf6bl4HgojvP8Wa94V7glxV75p/8Tsj5j5FwvFJfbbhlBJDNXiQ==",
           "requires": {
             "@rdfjs/data-model": "^1.1.0",
             "@types/rdf-js": "^3.0.0",
-            "asynciterator": "^3.0.0",
+            "asynciterator": "^3.0.1",
             "rdf-string": "^1.4.2",
             "rdf-terms": "^1.5.1"
           }
         },
         "@comunica/actor-rdf-resolve-hypermedia-sparql": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-sparql/-/actor-rdf-resolve-hypermedia-sparql-1.14.0.tgz",
-          "integrity": "sha512-0eAKkwqOzrbpZ2JgTvwFs5jMYHmkIIRkCV1UoeMuqDFpCnLjuvYuOW/8a3ug6HVOR8BrorCQgY4cRTKtwatc2A==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-sparql/-/actor-rdf-resolve-hypermedia-sparql-1.16.0.tgz",
+          "integrity": "sha512-G6OCciGr/mGg6TQ4+iEnWgSqYyrKmhXQ8UzkLPS6FJXyxWJoEoiHpebYMN9Zw6XycJKnZxlqVUrmIuz3Cxde5g==",
           "requires": {
-            "@comunica/actor-rdf-resolve-quad-pattern-sparql-json": "^1.14.0",
+            "@comunica/actor-rdf-resolve-quad-pattern-sparql-json": "^1.16.0",
             "@rdfjs/data-model": "^1.1.1",
             "@types/rdf-js": "^3.0.0",
-            "asynciterator": "^3.0.0",
+            "asynciterator": "^3.0.1",
             "rdf-terms": "^1.4.0",
-            "sparqlalgebrajs": "^2.2.2"
+            "sparqlalgebrajs": "^2.3.2"
           }
         },
         "@comunica/actor-rdf-resolve-quad-pattern-federated": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-federated/-/actor-rdf-resolve-quad-pattern-federated-1.14.0.tgz",
-          "integrity": "sha512-+wIdfFH+Ep4kSsuRUUOjJg56UfsrZgF0SvgpdngCGrmjgX9fwt1eVSk6rwefwaB7JQby20qhGBmAallIQs/QSA==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-federated/-/actor-rdf-resolve-quad-pattern-federated-1.16.0.tgz",
+          "integrity": "sha512-bHQLxjCtDHiUxIop8IWfReZhBPWpusPfc39A65VyQsZ7lBF/ZF21fTDaGJ8XlmiAYNBanDwjVIKe5ng3MGzwww==",
           "requires": {
             "@comunica/data-factory": "^1.14.0",
             "@rdfjs/data-model": "^1.1.1",
             "@types/rdf-js": "^3.0.0",
-            "asynciterator": "^3.0.0",
-            "lodash.omit": "^4.5.0",
+            "asynciterator": "^3.0.1",
             "rdf-terms": "^1.5.1"
           }
         },
         "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-hypermedia/-/actor-rdf-resolve-quad-pattern-hypermedia-1.14.0.tgz",
-          "integrity": "sha512-NKsNvv4m9MuAHF5OwVTYwk05jm0WCRwY720NyAjAnRIyiAgTIQijwCykgi2NZaKC6KVTPEQ3AO2ucvow57l9ag==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-hypermedia/-/actor-rdf-resolve-quad-pattern-hypermedia-1.16.0.tgz",
+          "integrity": "sha512-eNcn6N5Db5NyBPf4/on+baLr6pqeO86OcbfrjHkdU98MnR5CTXMF68/MCkwRLfcYooRG+o6z6EV/T/wonVeT8g==",
           "requires": {
-            "@comunica/utils-datasource": "^1.14.0",
+            "@comunica/utils-datasource": "^1.16.0",
             "@rdfjs/data-model": "^1.1.1",
             "@types/lru-cache": "^5.1.0",
             "@types/rdf-js": "^3.0.0",
-            "asynciterator": "^3.0.0",
+            "asynciterator": "^3.0.1",
             "lru-cache": "^6.0.0",
             "rdf-string": "^1.4.2",
             "rdf-terms": "^1.5.1"
           }
         },
         "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source/-/actor-rdf-resolve-quad-pattern-rdfjs-source-1.14.0.tgz",
-          "integrity": "sha512-qg326ppwtyAbqNAdqLdiE+3eEfWTLzY0uuIbnetZ+/z3VFYPcFMY0+2FeKo3fF+L03n76wNBE4X6Qoalk+/u/A==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source/-/actor-rdf-resolve-quad-pattern-rdfjs-source-1.16.0.tgz",
+          "integrity": "sha512-+APHJ2NNegd+dtbMIRnNKksBWk4lqEE70snWBKLavxcae0oq6rq3IvZypuARQETFfxICK9KtAtwg6Z7G19QjKw==",
           "requires": {
             "@types/rdf-js": "^3.0.0"
           }
         },
         "@comunica/actor-rdf-serialize-jsonld": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-1.14.0.tgz",
-          "integrity": "sha512-IPKBagjPSGWjV3DMokL2/Fcp3gPWVLek5sRtVOb9xTWfuVRjQSHCUT08yBtSQDucmmHwzunjmZLrKXk1Re/JOg==",
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-1.15.0.tgz",
+          "integrity": "sha512-+QeLhBWY9Ce0sNW6yDm7GoEdFNlMsQ01k71yBhaBRPhe/gYEbJc0chZAUoByCY0dJRqtfZK1Wc5gjfTrG/ctdQ==",
           "requires": {
             "jsonld-streaming-serializer": "^1.1.0"
           }
         },
         "@comunica/actor-rdf-serialize-n3": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-1.14.0.tgz",
-          "integrity": "sha512-UPoLzFPUgMfU42S6U6j5q1DmO/GVoEQOzwNwwZdsf/otgPAZbLHyXzYR9Kx5A0s0BJuR8vaj4ZIxVidoviSw7Q==",
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-1.15.0.tgz",
+          "integrity": "sha512-/9wY7o875w103A9a/SNpk65rFcp+bT3mSOnjV1bUnMVhvy73AsRG88uiwGUbS6GDFBPzA2j/l8OD+I4U3j6I7Q==",
           "requires": {
             "@types/n3": "^1.4.2",
             "@types/rdf-js": "^3.0.0",
@@ -1906,58 +1961,58 @@
           }
         },
         "@comunica/actor-sparql-parse-algebra": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-algebra/-/actor-sparql-parse-algebra-1.14.0.tgz",
-          "integrity": "sha512-MF50/5uQzi+Dnqdhl+eJYU0+rGJd0J2rAg7SpDGt2Kbcu+mJu/Sn/HV3tZMXWd6bjE2ve93EYOZPLQ7dLFg2NA==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-algebra/-/actor-sparql-parse-algebra-1.16.0.tgz",
+          "integrity": "sha512-hby1X7JYxgS1T84bLYna2Cs5XCA4cCaUJMAJ8emd/IyHoW0VT4N0moCofnswjykeJ9HgCOWMbs6FqfahZS1Tag==",
           "requires": {
             "@types/sparqljs": "^3.0.0",
             "rdf-string": "^1.4.2",
-            "sparqlalgebrajs": "^2.3.1",
-            "sparqljs": "^3.0.0"
+            "sparqlalgebrajs": "^2.3.2",
+            "sparqljs": "^3.1.1"
           }
         },
         "@comunica/actor-sparql-parse-graphql": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-graphql/-/actor-sparql-parse-graphql-1.14.0.tgz",
-          "integrity": "sha512-K8f/7iyT0jBmfqwNFwNSuj4tR/GRBEi3I2DnzzjYoRX1TfGJpOX4KHgOkR0BxWB8lPgF5O3CJJmMMiEhj8zXXw==",
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-graphql/-/actor-sparql-parse-graphql-1.15.0.tgz",
+          "integrity": "sha512-QggTh7b/LgzZRqKR+p46hXoJiH5ge/JTbWQM92QCRa2TsNm2hGpuvCwUS0VoPiUN+O/Vbtw6IH+09qJAnEt0+w==",
           "requires": {
             "graphql-to-sparql": "^2.1.0"
           }
         },
         "@comunica/actor-sparql-serialize-json": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-json/-/actor-sparql-serialize-json-1.14.0.tgz",
-          "integrity": "sha512-D31bViGwtEkcFGgLk55sPzkzIiyJgZLnCcKYBYANdc+rag6JWAGZ6LqOE9dEIPnd6N1mgCSKEKY3n+fNL3mlNA==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-json/-/actor-sparql-serialize-json-1.16.0.tgz",
+          "integrity": "sha512-9T6WlZtCOvYm37j7tgGvRCYO716naaqG4V2LbIYVcxoCxqUlfPcpE07eXt8GfWEG9R6QQuvk8UvEPqZrNiPmNQ==",
           "requires": {
             "@types/rdf-js": "^3.0.0",
             "rdf-string": "^1.4.2"
           }
         },
         "@comunica/actor-sparql-serialize-rdf": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-rdf/-/actor-sparql-serialize-rdf-1.14.0.tgz",
-          "integrity": "sha512-fa62ZiI10HGbS02g1OEO7OJG0H3w1Kw+UrVAzPtOSN6T/YHXIaBWDT1QzBitKMgufmk1SqSbSi+YF+2U3whbfw=="
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-rdf/-/actor-sparql-serialize-rdf-1.16.0.tgz",
+          "integrity": "sha512-KBwIuwzZp5qoSFPy+8n81x2uuV8P6pzwG3r2skdir+CfIygGb0Yxf0EzCKfVDBCYn/h4lFJPwMbqXbfflwN7Ww=="
         },
         "@comunica/actor-sparql-serialize-simple": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-simple/-/actor-sparql-serialize-simple-1.14.0.tgz",
-          "integrity": "sha512-485UrTM75wZEwbjpKkwdyxJ/syyJ9FlqWAM8zaMnqoW+JcaGzTHctStK4PvgStSLXtYoDctXKAa5QprZG4Aadw==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-simple/-/actor-sparql-serialize-simple-1.16.0.tgz",
+          "integrity": "sha512-Cu4MpzGlXQn/tI68fKuttny6cPmvyFBllypkZybPOtGwMY/TyA5FSd/GQLCagfP/gSm6XYnmK04D8gzY1Bwrlw==",
           "requires": {
             "@types/rdf-js": "^3.0.0"
           }
         },
         "@comunica/actor-sparql-serialize-sparql-json": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-json/-/actor-sparql-serialize-sparql-json-1.14.0.tgz",
-          "integrity": "sha512-/FvGjXmWnCPDr2hTltsrPUuEDf2HQcP4M2wF6l6oBbAfO7jyamiGhJhGwN1JEhv1WnW04fuP2OSZhSLw5Ii3mg==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-json/-/actor-sparql-serialize-sparql-json-1.16.0.tgz",
+          "integrity": "sha512-JVAPseFNzUT82mH9udR2QJXw0uWo6TcpHVYXk0JbvXOXwH4NBuAkXiYFBMv1ghbtpyN31Xol7Pa90mwGb8rrMw==",
           "requires": {
             "@types/rdf-js": "^3.0.0"
           }
         },
         "@comunica/actor-sparql-serialize-sparql-xml": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-xml/-/actor-sparql-serialize-sparql-xml-1.14.0.tgz",
-          "integrity": "sha512-2huuPdX0St6ITl/zU9NKT7xCsKj4P0z8oXhhOSdKIm7JSiE9HSR0fZuWtew3oJMRrCvqXMdpoIRK1P0HneBPCQ==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-xml/-/actor-sparql-serialize-sparql-xml-1.16.0.tgz",
+          "integrity": "sha512-udTwQMSGY25S9YePdMKrWgndHrxhcFpEZ2u8msTxbZkkJZhW8qKxh4rMUE5ESGsrFPwtlYQTX+gPu2LZ+zXAnA==",
           "requires": {
             "@types/rdf-js": "^3.0.0",
             "@types/xml": "^1.0.2",
@@ -1965,113 +2020,109 @@
           }
         },
         "@comunica/actor-sparql-serialize-stats": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-stats/-/actor-sparql-serialize-stats-1.14.0.tgz",
-          "integrity": "sha512-/kSNvHTujYhrR8D8+S+PPU2ayDJAKvIlgKGdk90jtBfQeZTAfXLBZPMqS+818XsD9h62LvPro3wtHujUFUaynQ==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-stats/-/actor-sparql-serialize-stats-1.16.0.tgz",
+          "integrity": "sha512-tGeOR5tgyP7yG7fSiPuI2Md+/ZFRJk8A6eSXGAGvZaNTGIhDmaF21jLfon/OUrJTO3jlsR1a1mZ2Hl5jshp2kA==",
           "requires": {
             "@types/rdf-js": "^3.0.0"
           }
         },
         "@comunica/actor-sparql-serialize-table": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-table/-/actor-sparql-serialize-table-1.14.0.tgz",
-          "integrity": "sha512-+ygFE6wK2G6h7ErtVbX2fDBMhDadBZ/1jM9ck0n/hHGXBx9Q5YmZZvHW8w1Fv+myZfAxkoMUnCCRDVRPZYt93w==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-table/-/actor-sparql-serialize-table-1.16.0.tgz",
+          "integrity": "sha512-Sj5AJqP5fPEL8Nr2sG6K64crd7FOChPzFojSE6L750SXutQSNDuJ/Zm8N1xfZxGsxTeYNUhzr+WxzSKoWuwzQA==",
           "requires": {
             "@types/rdf-js": "^3.0.0",
             "rdf-terms": "^1.4.0"
           }
         },
         "@comunica/actor-sparql-serialize-tree": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-tree/-/actor-sparql-serialize-tree-1.14.0.tgz",
-          "integrity": "sha512-ozEE54bRTuZt6twiuC6frun8G2yqiOklLnvzGL1G3+1aTEmT3cEFojBiQ80oPfMCJ5IOLouY9LKYu87mVUB9uA==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-tree/-/actor-sparql-serialize-tree-1.16.0.tgz",
+          "integrity": "sha512-9BMQ8nL4Cso2NOsiKrcGQp/Ccmer8jhfJowOQhRioLI54w2+lVGXBfR8t/Mj9T4bWabtgY8AES25ZjGS2hh2gg==",
           "requires": {
             "@types/rdf-js": "^3.0.0",
             "sparqljson-to-tree": "^2.0.0"
           }
         },
         "@comunica/bus-context-preprocess": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-context-preprocess/-/bus-context-preprocess-1.14.0.tgz",
-          "integrity": "sha512-2AjtI3bbPgqoCQivYzLGdO3CgPv7wpxt7IceRuV4ctSXSShP+MKshjZlQJqaOkGcj1lehMq4pbOx8VdslJgl8g=="
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-context-preprocess/-/bus-context-preprocess-1.15.0.tgz",
+          "integrity": "sha512-qB+DQX2YiXjc/vJ84fE9nW6XXgMDbYIwgtjn5wmfvQWjr+9p0yVjk32IMU9kRa7ETp9OytY/pHebvVHDhuHBYw=="
         },
         "@comunica/bus-http": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-1.14.0.tgz",
-          "integrity": "sha512-iKCl+2pVoCYJezXjstCZN+1tK9hc+vjkRDdseR08XFndpuO1XNvYmBXx2BfJP8huV7iOnjen4KHoxmvUfcHo5g==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-1.16.0.tgz",
+          "integrity": "sha512-3fWJA3Yh7Wj4clabg141FgAH+m8/InZ+BVPr7BqhO+7Jg0tXbvGDfai8N0SXWL7rCMkWjlPYkBHkzpQ8Dk0HAg==",
           "requires": {
             "is-stream": "^2.0.0",
             "web-streams-node": "^0.4.0"
           }
         },
         "@comunica/bus-http-invalidate": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-http-invalidate/-/bus-http-invalidate-1.14.0.tgz",
-          "integrity": "sha512-yPXXONePHqnaYH1DSY18ECL2TZPk/3YUlcQ7qoEFiaVwOdEXwdsSbjpk76zOVnKElmVemp7wpyH3NDWhv5KVhQ=="
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-http-invalidate/-/bus-http-invalidate-1.15.0.tgz",
+          "integrity": "sha512-RGURwbcUtD81ZYMMqs3EXB8ML35HENnGnrnrl0iO07R8HdJ/V5sczM8cxo5/+MXDpAqA9ao99AHJARwyHgoFmQ=="
         },
         "@comunica/bus-init": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-1.14.0.tgz",
-          "integrity": "sha512-BZaBp2M1sd8Ad1LL5chzWh8RxlipBLeiea9m0l7nF7fAq8mAz051NV4ZnteaumW6691fgAaMuoYkWfXr2azOVA=="
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-1.15.0.tgz",
+          "integrity": "sha512-HwVTEznx2H7GvcfQAREz52QF8xXT1AqxkJDnI9vTeGvLpWrM+LVOAJZxBcYFFK3X3bEhTsPfDVzikziMGqZuZw=="
         },
         "@comunica/bus-optimize-query-operation": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-1.14.0.tgz",
-          "integrity": "sha512-6G+hswg3wgC11kOhJ6IafZQ/0XGW1vZUoBEEXPo88kXOml5Aj3EBJvKuvY3fEtpUV9s5AQ5pIdi2enNxZgW9IQ==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-1.16.0.tgz",
+          "integrity": "sha512-7mvHenP7semqGlWge4EIvueK1/s4TjMpyL/RKF0Twa8Fwp0r66dFjprkAitV7K95U4FJvD0KSJPWTnQsJBdxrg==",
           "requires": {
-            "sparqlalgebrajs": "^2.2.2"
+            "sparqlalgebrajs": "^2.3.2"
           }
         },
         "@comunica/bus-query-operation": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-query-operation/-/bus-query-operation-1.14.0.tgz",
-          "integrity": "sha512-TgkbRYg48VTRH7wwfBsXjuXrxtUaECMfDf74qnyRnqRQjV1bee7w/jfhHECr6rswDhs3EWNJyYaxpfxHq36QSw==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-query-operation/-/bus-query-operation-1.16.0.tgz",
+          "integrity": "sha512-xusr0PelD5ej1B9+ff7AFDXRMidDR167Lzazaits7wNd400sG2RpIJjnEvNqU6g6d0R5WnUWCpCuv4hFQZ15sQ==",
           "requires": {
             "@types/rdf-js": "^3.0.0",
-            "asynciterator": "^3.0.0",
+            "asynciterator": "^3.0.1",
             "immutable": "^3.8.2"
           }
         },
         "@comunica/bus-rdf-dereference": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference/-/bus-rdf-dereference-1.14.0.tgz",
-          "integrity": "sha512-pazNqmtKglXsI3YvtwR7JpKNnakKUu4/nuXuRC64JUi1EW2GbKEzR0rjZ99m007oUKjvmOsvkCu0ceYZswH+6g==",
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference/-/bus-rdf-dereference-1.15.0.tgz",
+          "integrity": "sha512-4vXq8e51zK1gkw5lxL2HkqYx/Wig215w8Bi3jguUTM/10EQW7KgebhRxeFU/EQOamFTMeS5anOu5BVfNps8rJQ==",
           "requires": {
             "@types/rdf-js": "^3.0.0"
           }
         },
         "@comunica/bus-rdf-dereference-paged": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference-paged/-/bus-rdf-dereference-paged-1.14.0.tgz",
-          "integrity": "sha512-6qq+kWAm0n/x1WZSVFcmMC4+CvBffAOEbc2o454R8WD0DvzRcLtLPJii101u5pObC6kZPGh2X1xisfOgdx9PMQ==",
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference-paged/-/bus-rdf-dereference-paged-1.15.0.tgz",
+          "integrity": "sha512-xejwEanK8yaI/ST1SDE2Tjs9f/PsS5SvtYIVEZuWew9Ey4UlxcW/Tsz4m5YA40DeYbXaXg7m40ZeWJxwiislrw==",
           "requires": {
             "@types/rdf-js": "^3.0.0"
           }
         },
         "@comunica/bus-rdf-join": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join/-/bus-rdf-join-1.14.0.tgz",
-          "integrity": "sha512-+GJNtLFOaEOgkSVlvuVOBbX6xIJRLKEFGNlssnbxGYt8eYoEcMS7hKzIJrqWSxEr8P7ReIEEP3bHMEDfHVdDrQ==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join/-/bus-rdf-join-1.16.0.tgz",
+          "integrity": "sha512-v2RilDXPIc1sOtGnhskNqvbeyp4jOBTTUnHUEHCIdopZVUhEIj+zpZdHFoPOIbtHK6eQlQ0Ckx3E3mX84fZVyA==",
           "requires": {
-            "@types/lodash.intersection": "^4.4.3",
-            "@types/lodash.union": "^4.6.3",
-            "@types/rdf-js": "^3.0.0",
-            "lodash.intersection": "^4.4.0",
-            "lodash.union": "^4.6.0"
+            "@types/rdf-js": "^3.0.0"
           }
         },
         "@comunica/bus-rdf-metadata": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata/-/bus-rdf-metadata-1.14.0.tgz",
-          "integrity": "sha512-O8A0GH5QYpVudHwjCUnF5ukn/PXjXIHXcGzpRTCStEIbNcVytETXeG9ll1rEfu65GziZlpk95/d0Rb140iEIHg==",
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata/-/bus-rdf-metadata-1.15.0.tgz",
+          "integrity": "sha512-XhyMkScTBA0KUPTHtmO+kxAUyHhvuigiC6NzAoBZ9wm4y+r3aZ++mpBpAv/Fyma5GiT19EAW2pa8ew7CV9GR3A==",
           "requires": {
             "@types/rdf-js": "^3.0.0"
           }
         },
         "@comunica/bus-rdf-metadata-extract": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-1.14.0.tgz",
-          "integrity": "sha512-yRf77d7mf59IPZ8o4XzVq2MAET64lyLmG5bbeJEE11ENSUZM9MClYp5uYE51xENURv65nPbpRI3S+Bt9qZ/PAQ==",
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-1.15.0.tgz",
+          "integrity": "sha512-uxLy3hvpWuLoopoG5clYb3imhQXHGHMKHXe97jfvXA0hjoWleNtD0KRfhs+45YCBXqfNC9PVypTb9eM6SVILNQ==",
           "requires": {
             "@types/rdf-js": "^3.0.0",
             "graphql-ld": "^1.1.0",
@@ -2079,77 +2130,75 @@
           }
         },
         "@comunica/bus-rdf-parse": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-1.14.0.tgz",
-          "integrity": "sha512-JUeCd85gg0XXXwVz3gOQ9bj7KZ2Em9SaM22DoTGeZI5uf6P/VgV9u2EVIPWomP3bI8GAcYq+KK19JtzR5VN4Fw==",
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-1.15.0.tgz",
+          "integrity": "sha512-6cGGUBgorkJ6hr5U235qSrlK1m7rPpIM8W6o9kbRAw149AKap1XFF3OXpAYqat2eB4Cbs1J2PP9wg1/s/uOsww==",
           "requires": {
-            "@comunica/actor-abstract-mediatyped": "^1.14.0",
+            "@comunica/actor-abstract-mediatyped": "^1.15.0",
             "@types/rdf-js": "^3.0.0"
           }
         },
         "@comunica/bus-rdf-parse-html": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-1.14.0.tgz",
-          "integrity": "sha512-+gV8YmfqWTPplOMeWEfkJjJTtCz3zJnkjmlXotxljHVjOZNUBVZm3OifnbScWDzbrOIFpj8XVJO1k3Ya75WzvQ==",
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-1.15.0.tgz",
+          "integrity": "sha512-7F/kDrNf9X//IrO/CK4LpwM5f+mFHLa/wsPc2RubyhiFN3P3KWU6NWxjDJRT9yP85EmW4KknXWwF8AOTvbKF1A==",
           "requires": {
             "@types/rdf-js": "^3.0.0"
           }
         },
         "@comunica/bus-rdf-resolve-hypermedia": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia/-/bus-rdf-resolve-hypermedia-1.14.0.tgz",
-          "integrity": "sha512-BiHl3pnkswVQ1lOCefY9COFzOtLVAMNrYInCPC0kyf3rB+pzcRClnyFtB0jh6llmN8rbrc790SQ9BHaDtfXWow==",
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia/-/bus-rdf-resolve-hypermedia-1.15.0.tgz",
+          "integrity": "sha512-mnSsNMa2FS6x0b0K453J4c2+1UQoe2WX/p3UXfF7YocWFc7eL7JUsZO8+XZ1Pq8WaPpz+sUeaz+JtIYgVtqSGg==",
           "requires": {
             "@types/rdf-js": "^3.0.0",
-            "asynciterator": "^3.0.0",
+            "asynciterator": "^3.0.1",
             "asyncreiterable": "^2.0.0"
           }
         },
         "@comunica/bus-rdf-resolve-hypermedia-links": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia-links/-/bus-rdf-resolve-hypermedia-links-1.14.0.tgz",
-          "integrity": "sha512-Qd/i2Ab9TKUzyhAzWdL4zO3EaacTx9O14yBc9mZvcoZskx/hn+ufEbAeh8sBjRcijs9ZkHR7dbMGJILCjv0nUQ=="
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia-links/-/bus-rdf-resolve-hypermedia-links-1.15.0.tgz",
+          "integrity": "sha512-AJD48ftgMdPj5x0hMTRkzNHeywsMqWnXOK7c6L2m3TlUyMtw5PWNYKd2CD1qyXE7xmSi2cKLKA5TKDkQqV7GCg=="
         },
         "@comunica/bus-rdf-resolve-quad-pattern": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-quad-pattern/-/bus-rdf-resolve-quad-pattern-1.14.0.tgz",
-          "integrity": "sha512-xQfVlBunATBZ7SLikgkpRvkbYZGaWSmSVCVXf5JXQITdK9bq1YwGh221gYIXgSZNBJt7s8UyGZOmCHYXcv9rNQ==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-quad-pattern/-/bus-rdf-resolve-quad-pattern-1.16.0.tgz",
+          "integrity": "sha512-CHZQcBFVMeUiB2DyGWzDRzvXO+s7uNS6SwnrvXVujCpdYFKfB15uG9mcpc8tZGwHDr18xq6iuLZcEKMl5wqGjA==",
           "requires": {
             "@types/rdf-js": "^3.0.0",
-            "asynciterator": "^3.0.0",
+            "asynciterator": "^3.0.1",
             "asyncreiterable": "^2.0.0"
           }
         },
         "@comunica/bus-rdf-serialize": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-1.14.0.tgz",
-          "integrity": "sha512-ChqyYnqnxI0RdI/T3w9Ys0YtwBOFVFFRrg5+tFeVnZCybBy7tlO+5v2JJ7yIB+ORF15vYlZmMv+y+HH+Qjs0rQ==",
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-1.15.0.tgz",
+          "integrity": "sha512-c1uJF1LkJ96zscMCe+CB2fLbXhlJ0o8PPVRMm3Jk7/rc8WY5bUxSxf1SFbA/jkOZtcZy59wFHDvPf/NM74ADBg==",
           "requires": {
-            "@comunica/actor-abstract-mediatyped": "^1.14.0",
+            "@comunica/actor-abstract-mediatyped": "^1.15.0",
             "@types/rdf-js": "^3.0.0"
           }
         },
         "@comunica/bus-sparql-parse": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-sparql-parse/-/bus-sparql-parse-1.14.0.tgz",
-          "integrity": "sha512-grzbZ8WIYcbMyS0wBrr+CxrpcLGbLE9jY7fwB+aX9nd5YmSXAdS1l5z2GFrNXQOqDtZOgeEZM/wzEwb63E/Ttw=="
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-sparql-parse/-/bus-sparql-parse-1.15.0.tgz",
+          "integrity": "sha512-4aFz5qnnnPxezK/vtvltqqUlN0NhYNFEQwXYZf6Yi2dSS/Hs4cU4kYcldXxIXeBfRQkaoUtTCr0lCUg5uOyqIQ=="
         },
         "@comunica/bus-sparql-serialize": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/bus-sparql-serialize/-/bus-sparql-serialize-1.14.0.tgz",
-          "integrity": "sha512-nAZi1y/gBwv+W3JFS+aqkFCT6ZqZF3WQ8+AEd+NN11eIP7t7Cno/sLQTLsMN0viYO7BCW0mjEDIuVN6EN2U8aw==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-sparql-serialize/-/bus-sparql-serialize-1.16.0.tgz",
+          "integrity": "sha512-LLPheBBYBuSAweou+4kQf0Gop/lNORXOuaDfsHemLG6VqNmWzYyl79rnjd7yTLcZn/QVMUUYDD21CPY8OU5lJQ==",
           "requires": {
-            "@comunica/actor-abstract-mediatyped": "^1.14.0"
+            "@comunica/actor-abstract-mediatyped": "^1.15.0"
           }
         },
         "@comunica/core": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-1.14.0.tgz",
-          "integrity": "sha512-NIKjJIM0mvMFHCFQgN7XFi3TbCkhPCGHpiNXIOFtwbqxMCaXbaB2YF5kXosjEWxdoPF6FAJjxkoy3WbvdtWKtg==",
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-1.15.0.tgz",
+          "integrity": "sha512-Mg/fpufyK4hVKX2vgP8oapu4ZpyugNRxyI/1AX7zlhSkYpE+ldK5YQaGG/sb+fq+s2sAtE1Ocd+thCgF4wv+8w==",
           "requires": {
-            "@types/lodash.assign": "^4.2.3",
-            "immutable": "^3.8.2",
-            "lodash.assign": "^4.2.0"
+            "immutable": "^3.8.2"
           }
         },
         "@comunica/data-factory": {
@@ -2161,75 +2210,64 @@
           }
         },
         "@comunica/logger-pretty": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-1.14.0.tgz",
-          "integrity": "sha512-yLpR0fzPyRbY49PyBjO6955z76KeIT6Bwr6GOtHHTMMDKGqc5gMrtAJSZ4iE+URtTy8e+Mww7hOE6O97TogkHg=="
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-1.15.0.tgz",
+          "integrity": "sha512-Ta0u/YHHgSvX9Au8JqzhgqmNiPLwFW2L1ZLnUR3V0J+uQDL2PEayWnw+xrDyVKgYJaffevJYHowjn4c4D5DxFA=="
         },
         "@comunica/logger-void": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/logger-void/-/logger-void-1.14.0.tgz",
-          "integrity": "sha512-rkmAiYreoNe8Vo5Qb6Afn9sKV+8pAbXsRS9nRpKtpaq+G/NHBFGGYh9tJ/B8V6LmUmsZvoHD4bS1a6ykV18mHg=="
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/logger-void/-/logger-void-1.15.0.tgz",
+          "integrity": "sha512-nU0bJ56hOAURnz4uDNbeldAJ88OduRQMtHEeKTSkR+ATArP/ShXFWLgKcxRnU9ELSsA7k9HlvAFpvag5+eNs8g=="
         },
         "@comunica/mediator-all": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/mediator-all/-/mediator-all-1.14.0.tgz",
-          "integrity": "sha512-9dZZbjsLbJOFfvt3yZzKMHcZm64wwBv1wgrspTanEzJi/mD/NfQ1D+zQ/tWqgoHKoPSaOQPBok1idxdC82DCjg==",
-          "requires": {
-            "lodash": "^4.17.4"
-          }
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/mediator-all/-/mediator-all-1.15.0.tgz",
+          "integrity": "sha512-uALhqOxGIT/gBXWkIVE+PTITf5EIDNL2UD9GRffdgc1Qg74prWcMZ4+gYczBOMUhqZHE605QsXXO8NkT4xP14A=="
         },
         "@comunica/mediator-combine-pipeline": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-1.14.0.tgz",
-          "integrity": "sha512-ga3gY7xuhZQOshU+tSgOvgeeq1JwjsKTNyTvlb/KI2kWlALcnzy9y09LhGhjCIfy+gESnvdx1LykPHSN0Is5ww=="
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-1.15.0.tgz",
+          "integrity": "sha512-XYf+rOSF1Tj5JX8geHUt5O8BJmLqyRXXYZQe2nlwGoe66hshMKpzAu38m5uDpARrJ4dPxU0PrH34x1Wug77lpg=="
         },
         "@comunica/mediator-combine-union": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-1.14.0.tgz",
-          "integrity": "sha512-zbfRoWq0JvjlQZE0A1sLnM9EPw71A4F7b5mTZfUomSG4GEnN16a7YnjIxBEaXLEPjaTCzrsqGmrxg03Sekmq+w==",
-          "requires": {
-            "@types/lodash.defaults": "^4.2.3",
-            "lodash.defaults": "^4.2.0"
-          }
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-1.15.0.tgz",
+          "integrity": "sha512-TPzfXuKRVBEpjb+/S8v2C8uvgi8BTjtg1htL/qY/xI2fYqRcLZGl+D5MZEESmwpmm19cBfg87CbF+ROn6L3+IQ=="
         },
         "@comunica/mediator-number": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-1.14.0.tgz",
-          "integrity": "sha512-IOauFlga1ksDT2evHaFlQmu4ngkY7nD+Wv3musw76G1GrMip7AYPDf1WKvEL6bMoKkCy2xqQ8MgyimcDTP8IkA=="
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-1.15.0.tgz",
+          "integrity": "sha512-d1jwHVN6rELFzEPb+CDqEjItAJ4/AqiP1Vp+Z/PBucLjM9EEonQMjQzqrkRV/Oy6cBXfSQDhXuSvftfl/zUCjg=="
         },
         "@comunica/mediator-race": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-1.14.0.tgz",
-          "integrity": "sha512-gwbRqddnBYQOGuQOofrs8MUgHORO42QVfkVFPlCtPQMMzMOMx4VWuD8YjWz1oNaNSIjZlmYOPZTYx95uhUe8Fw=="
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-1.15.0.tgz",
+          "integrity": "sha512-MVESJnkgSoPaCkNNN8RDm0B06d0JNL4QOvRZFuFETY4/D+OwIpcEf0EGButQsDUlelAk5n/sFssLMqo2tw65SA=="
         },
         "@comunica/runner": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/runner/-/runner-1.14.0.tgz",
-          "integrity": "sha512-m3j1y1zdclu0UXkrRAJAL13mPMGjRvTxOESrHSxSTe63DvWMTa+gr5TYZL0TGQ7p7Kw4AktEufCZBINH9akqgg==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/runner/-/runner-1.16.0.tgz",
+          "integrity": "sha512-ZQuTt10UpcUbiXu94MSFCgaYkraCtgXewEbXus5Jf0OUbSqa/fkxwWs4wTxak/9CjtFLMb4GO3jfoYoeWbqtfA==",
           "requires": {
-            "@types/lodash.assign": "^4.2.3",
-            "@types/lodash.defaults": "^4.2.3",
-            "componentsjs": "^3.4.1",
-            "lodash.assign": "^4.2.0",
-            "lodash.defaults": "^4.2.0"
+            "componentsjs": "^3.4.1"
           }
         },
         "@comunica/runner-cli": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/runner-cli/-/runner-cli-1.14.0.tgz",
-          "integrity": "sha512-QSF7uI3J/3qiYsLD1E8rkV9bkkFlQ79wNGHn2G/kykUS8PLfMipibOqA88Xhh4Tn68vlPwuomCKLxEzhZ7qA0w==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/runner-cli/-/runner-cli-1.16.0.tgz",
+          "integrity": "sha512-9XfRqACWeppe/po/UMIN4MH+gU/8YszRqyPG02vd9k0AnPXYMK5AXPj4ge3D0HQE+ENb2y9C5xe516w0yl8eBw==",
           "requires": {
-            "@comunica/runner": "^1.14.0"
+            "@comunica/runner": "^1.16.0"
           }
         },
         "@comunica/utils-datasource": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@comunica/utils-datasource/-/utils-datasource-1.14.0.tgz",
-          "integrity": "sha512-T2eIs2xKOQVuT/WkB+DTHvq8GXz4tDtVYLPZktS7CEgHbj16+S7rEtTXMXHXaPCiVFKJCqE+3zCtpJPcDU/wgw==",
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/@comunica/utils-datasource/-/utils-datasource-1.16.0.tgz",
+          "integrity": "sha512-MWng1lz62YT5VLvwFvBNc119U6aNvX7oL8j7YdgRyLulB14gYEp5njuqRjbz1WFa1TtDUJxYGMPyskSMdzGilw==",
           "requires": {
-            "@comunica/bus-rdf-resolve-quad-pattern": "^1.14.0",
+            "@comunica/bus-rdf-resolve-quad-pattern": "^1.16.0",
             "arrayify-stream": "^1.0.0",
-            "asynciterator": "^3.0.0",
+            "asynciterator": "^3.0.1",
             "asyncreiterable": "^2.0.0"
           }
         },
@@ -2251,9 +2289,9 @@
           }
         },
         "asynciterator": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/asynciterator/-/asynciterator-3.0.0.tgz",
-          "integrity": "sha512-8aq8lNFDG47H/LlEFHLze17T+zjsHP7yscvEdyWh8MYBEI9CkpBbKuFx6FT4dmMVsBZ0D1LUq8aIh8+vHd/74Q=="
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/asynciterator/-/asynciterator-3.0.1.tgz",
+          "integrity": "sha512-i63IZ/CLbSwT+9+jezA8BFnMmmOylNN+2/yNqMSr37IdzjPLnYMfEvTOFt46hDA+san7k9CZN6gEzCgCTTfAWA=="
         },
         "asyncjoin": {
           "version": "1.0.1",
@@ -2282,6 +2320,53 @@
           "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
           "requires": {
             "yallist": "^4.0.0"
+          }
+        },
+        "n3": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/n3/-/n3-1.6.2.tgz",
+          "integrity": "sha512-9R45WRNxNPblKLbXGwR9IvtaVvdr80vRxME79fhWnqBzHb2GcP6lS77Mvf8Fx6Wpfn8PpBTdggceWsSMDGY/SA==",
+          "requires": {
+            "queue-microtask": "^1.1.2",
+            "readable-stream": "^3.6.0"
+          }
+        },
+        "sparqlalgebrajs": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-2.3.2.tgz",
+          "integrity": "sha512-QnjSz25c6ruALbxxD7e9E64hoi/yPMz5MzxUIjLEiTob2zWoM4Pj6GlYZAMnxcCdXXURZO+n0Obt/8XhQj4XiQ==",
+          "requires": {
+            "@rdfjs/data-model": "^1.1.2",
+            "fast-deep-equal": "^3.1.1",
+            "minimist": "^1.2.5",
+            "rdf-string": "^1.3.1",
+            "sparqljs": "^3.1.1"
+          }
+        },
+        "sparqlee": {
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/sparqlee/-/sparqlee-1.4.3.tgz",
+          "integrity": "sha512-HVWj816xZqUO14/kkA9I/OS+uF8zHe7MGCmoGb4gPcO2KcenF8hg4SssftcQgxVJzsI4RQV91rXhDYdBb1WF9g==",
+          "requires": {
+            "@rdfjs/data-model": "^1.1.0",
+            "@types/create-hash": "^1.2.0",
+            "@types/rdf-js": "^3.0.0",
+            "@types/uuid": "^8.0.0",
+            "create-hash": "^1.2.0",
+            "decimal.js": "^10.2.0",
+            "immutable": "^3.8.2",
+            "rdf-string": "^1.1.1",
+            "sparqlalgebrajs": "^2.1.0",
+            "uri-js": "^4.2.2",
+            "uuid": "^8.0.0"
+          }
+        },
+        "sparqljs": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.1.1.tgz",
+          "integrity": "sha512-HYSwEu++souL4YjJbRx+3dJ1aNYNuR+BbZdPmdrmD4QMSO14J63BEshpcSURcNRsuriOI+05wo2AaxVvpjhgkg==",
+          "requires": {
+            "n3": "^1.6.0"
           }
         },
         "yallist": {
@@ -2552,6 +2637,14 @@
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
+    "@types/create-hash": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/create-hash/-/create-hash-1.2.2.tgz",
+      "integrity": "sha512-Fg8/kfMJObbETFU/Tn+Y0jieYewryLrbKwLCEIwPyklZZVY2qB+64KFjhplGSw+cseZosfFXctXO+PyIYD8iZQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -2584,62 +2677,6 @@
       "version": "4.14.157",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.157.tgz",
       "integrity": "sha512-Ft5BNFmv2pHDgxV5JDsndOWTRJ+56zte0ZpYLowp03tW+K+t8u8YMOzAnpuqPgzX6WO1XpDIUm7u04M8vdDiVQ=="
-    },
-    "@types/lodash.assign": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.assign/-/lodash.assign-4.2.6.tgz",
-      "integrity": "sha512-SaReADQZqf99FUWZ/gHICOAhLfBvaUmVb9y8xCw7o5WDuqDG0YfN1a+by29eipPcV4FITfPbQMJQiOGAeOb4fw==",
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
-    "@types/lodash.defaults": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.defaults/-/lodash.defaults-4.2.6.tgz",
-      "integrity": "sha512-JsUJheQIG2Yf/n/QRUMGXT76/7x4tLU5i0kxIPeoOcTIh9yNzdEzCHWbwD8mTf+VncGwYZiho+F2u1pEBsGswA==",
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
-    "@types/lodash.find": {
-      "version": "4.6.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.find/-/lodash.find-4.6.6.tgz",
-      "integrity": "sha512-rpfXWzKWaw12XMcdQYA7f0xVmkXwJkhPPON69pGVFNYF6/66CduGyLiYnoZk1xBOvGwMnmyrCZ/yJewPO4OMeg==",
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
-    "@types/lodash.intersection": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.intersection/-/lodash.intersection-4.4.6.tgz",
-      "integrity": "sha512-6ewsKax7+HgT+7mEhzXT6tIyIHc/mjCwZJnarvLbCrtW21qmDQHWbaJj4Ht4DQDBmMdnvZe8APuVlsMpZ5E5mQ==",
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
-    "@types/lodash.mapvalues": {
-      "version": "4.6.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.mapvalues/-/lodash.mapvalues-4.6.6.tgz",
-      "integrity": "sha512-Mt9eg3AqwAt5HShuOu8taiIYg0sLl4w3vDi0++E0VtiOtj9DqQHaxVr3wicVop0eDEqr5ENbht7vsLJlkMHL+w==",
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
-    "@types/lodash.union": {
-      "version": "4.6.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.union/-/lodash.union-4.6.6.tgz",
-      "integrity": "sha512-Wu0ZEVNcyCz8eAn6TlUbYWZoGbH9E+iOHxAZbwUoCEXdUiy6qpcz5o44mMXViM4vlPLLCPlkAubEP1gokoSZaw==",
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
-    "@types/lodash.uniq": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.uniq/-/lodash.uniq-4.5.6.tgz",
-      "integrity": "sha512-XHNMXBtiwsWZstZMyxOYjr0e8YYWv0RgPlzIHblTuwBBiWo2MzWVaTBihtBpslb5BglgAWIeBv69qt1+RTRW1A==",
-      "requires": {
-        "@types/lodash": "*"
-      }
     },
     "@types/lru-cache": {
       "version": "5.1.0",
@@ -2747,6 +2784,11 @@
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@types/uritemplate/-/uritemplate-0.3.4.tgz",
       "integrity": "sha512-1D8mJEeQEXynoPQKJkneIK+tXaM2Qnk6c80RBQPV/O2ToypI4mlqXy5jojnYKjTX2Q+EMNMOWt0wNdLbb2MUpA=="
+    },
+    "@types/uuid": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ=="
     },
     "@types/xml": {
       "version": "1.0.5",
@@ -6461,6 +6503,14 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.4.2.tgz",
       "integrity": "sha512-74yYjS0W4N3nYDGbXBZrNsqDmhBTjqChTETO9heC2G2M3iMYaIPtEfUikNsBWUj4+4bIKyqL7vAntWBTfJpFFA==",
+      "requires": {
+        "@rdfjs/data-model": "^1.1.1"
+      }
+    },
+    "rdf-string-ttl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-string-ttl/-/rdf-string-ttl-1.0.1.tgz",
+      "integrity": "sha512-QdOztnXuQTS5HwS2YTUkY9KUdyjyMYCX4QITfAAAtJnGqQkfah1L+VdV3E+Z3NKp/CBXLqZs/oMZe5J7pUEzpw==",
       "requires": {
         "@rdfjs/data-model": "^1.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@comunica/core": "^1.13.0",
     "@hapi/hoek": "9.x.x",
     "@hapi/joi": "17.x.x",
-    "@netwerk-digitaal-erfgoed/network-of-terms-catalog": "^1.0.1",
+    "@netwerk-digitaal-erfgoed/network-of-terms-catalog": "^2.0.0",
     "@oclif/command": "1.x.x",
     "@rdfjs/data-model": "^1.1.2",
     "cli-ux": "5.x.x",

--- a/src/commands/sources/list.ts
+++ b/src/commands/sources/list.ts
@@ -21,7 +21,7 @@ export class ListSourcesCommand extends Command {
         get: (distribution: DatasetDistribution) => distribution.dataset.name,
       },
       distributionId: {
-        header: 'Distribution URI',
+        header: 'Source URI',
         get: (distribution: DatasetDistribution) =>
           distribution.distribution.iri.toString(),
       },

--- a/src/commands/sources/list.ts
+++ b/src/commands/sources/list.ts
@@ -3,26 +3,40 @@ import {Command} from '@oclif/command';
 import {
   Catalog,
   Dataset,
+  Distribution,
 } from '@netwerk-digitaal-erfgoed/network-of-terms-catalog';
+
+type DatasetDistribution = {
+  dataset: Dataset;
+  distribution: Distribution;
+};
 
 export class ListSourcesCommand extends Command {
   static description = 'List queryable sources';
 
-  protected render(datasets: readonly Dataset[]): void {
-    cli.table(datasets as Dataset[], {
+  protected render(distributions: readonly DatasetDistribution[]): void {
+    cli.table(distributions as DatasetDistribution[], {
       distributionTitle: {
         header: 'Source Name',
-        get: (dataset: Dataset) => dataset.name,
+        get: (distribution: DatasetDistribution) => distribution.dataset.name,
       },
       distributionId: {
-        header: 'Source ID',
-        get: (dataset: Dataset) => dataset.identifier,
+        header: 'Distribution URI',
+        get: (distribution: DatasetDistribution) =>
+          distribution.distribution.iri.toString(),
       },
     });
   }
 
   async run(): Promise<void> {
     const catalog = await Catalog.default();
-    this.render(catalog.datasets);
+    const distributions = catalog.datasets.flatMap((dataset: Dataset) =>
+      dataset.distributions.map(distribution => ({
+        dataset,
+        distribution,
+      }))
+    );
+
+    this.render(distributions);
   }
 }

--- a/src/commands/sources/query.ts
+++ b/src/commands/sources/query.ts
@@ -21,7 +21,7 @@ export class QuerySourcesCommand extends Command {
   static flags: flags.Input<any> = {
     distributions: flags.string({
       description:
-        'URIs of distributions to query, comma-separated, e.g. "https://www.wikidata.org/sparql,https://data.netwerkdigitaalerfgoed.nl/rkd/rkdartists/sparql"',
+        'URIs of sources to query, comma-separated, e.g. "https://www.wikidata.org/sparql,https://data.netwerkdigitaalerfgoed.nl/rkd/rkdartists/sparql"',
       required: true,
     }),
     query: flags.string({

--- a/src/commands/sources/query.ts
+++ b/src/commands/sources/query.ts
@@ -5,11 +5,11 @@ import * as Logger from '../../helpers/logger';
 import {QueryResult} from '../../services/query';
 import * as RDF from 'rdf-js';
 import {Term} from '../../services/terms';
-import {Catalog} from '@netwerk-digitaal-erfgoed/network-of-terms-catalog';
+import {Catalog, IRI} from '@netwerk-digitaal-erfgoed/network-of-terms-catalog';
 import {newEngine} from '@comunica/actor-init-sparql';
 
 interface Row {
-  distributionTitle: string;
+  datasetTitle: string;
   termUri: string;
   prefLabels: string;
   altLabels: string;
@@ -19,9 +19,9 @@ export class QuerySourcesCommand extends Command {
   static description = 'Query sources for terms';
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   static flags: flags.Input<any> = {
-    identifiers: flags.string({
+    distributions: flags.string({
       description:
-        'Identifiers of sources to query, comma-separated, e.g. "nta,rkdartists"',
+        'URIs of distributions to query, comma-separated, e.g. "https://www.wikidata.org/sparql,https://data.netwerkdigitaalerfgoed.nl/rkd/rkdartists/sparql"',
       required: true,
     }),
     query: flags.string({
@@ -36,12 +36,14 @@ export class QuerySourcesCommand extends Command {
     }),
   };
 
-  protected render(results: QueryResult[]): void {
+  protected render(results: QueryResult[], catalog: Catalog): void {
     const rowsPerDistribution = results.map((result: QueryResult): Row[] => {
       return result.terms.map(
         (term: Term): Row => {
           return {
-            distributionTitle: result.dataset.distribution.url.toString(),
+            datasetTitle:
+              catalog.getDatasetByDistributionIri(result.distribution.iri)
+                ?.name ?? '',
             termUri: term.id!.value,
             prefLabels: term.prefLabels
               .map((prefLabel: RDF.Term) => prefLabel.value)
@@ -56,7 +58,7 @@ export class QuerySourcesCommand extends Command {
     const rows = ([] as Row[]).concat(...rowsPerDistribution); // Flatten array
 
     cli.table(rows, {
-      distributionTitle: {
+      datasetTitle: {
         header: 'Source Name',
       },
       termUri: {
@@ -73,9 +75,9 @@ export class QuerySourcesCommand extends Command {
 
   async run(): Promise<void> {
     const {flags} = this.parse(QuerySourcesCommand);
-    const sources = flags.identifiers
+    const sources = flags.distributions
       .split(',')
-      .map((distributionId: string) => distributionId.trim());
+      .map((distributionId: string) => new IRI(distributionId.trim()));
 
     const logger = Logger.getCliLogger({
       name: 'cli',
@@ -88,6 +90,6 @@ export class QuerySourcesCommand extends Command {
       sources,
       query: flags.query,
     });
-    this.render(results);
+    this.render(results, catalog);
   }
 }

--- a/src/commands/sources/query.ts
+++ b/src/commands/sources/query.ts
@@ -19,7 +19,7 @@ export class QuerySourcesCommand extends Command {
   static description = 'Query sources for terms';
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   static flags: flags.Input<any> = {
-    distributions: flags.string({
+    uris: flags.string({
       description:
         'URIs of sources to query, comma-separated, e.g. "https://www.wikidata.org/sparql,https://data.netwerkdigitaalerfgoed.nl/rkd/rkdartists/sparql"',
       required: true,
@@ -75,7 +75,7 @@ export class QuerySourcesCommand extends Command {
 
   async run(): Promise<void> {
     const {flags} = this.parse(QuerySourcesCommand);
-    const sources = flags.distributions
+    const sources = flags.uris
       .split(',')
       .map((distributionId: string) => new IRI(distributionId.trim()));
 

--- a/src/server/resolvers.ts
+++ b/src/server/resolvers.ts
@@ -2,16 +2,16 @@ import {DistributionsService} from '../services/distributions';
 import {QueryResult} from '../services/query';
 import * as RDF from 'rdf-js';
 import {Term} from '../services/terms';
-import {Dataset} from '@netwerk-digitaal-erfgoed/network-of-terms-catalog';
+import {Dataset, IRI} from '@netwerk-digitaal-erfgoed/network-of-terms-catalog';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function listSources(object: any, args: any, context: any): Promise<any> {
-  return context.catalog.datasets.map((dataset: Dataset) => {
-    return {
-      identifier: dataset.identifier,
+  return context.catalog.datasets.flatMap((dataset: Dataset) =>
+    dataset.distributions.map(distribution => ({
+      uri: distribution.iri.toString(),
       name: dataset.name,
-    };
-  });
+    }))
+  );
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -22,14 +22,18 @@ async function queryTerms(object: any, args: any, context: any): Promise<any> {
     comunica: context.comunica,
   });
   const results = await service.queryAll({
-    sources: args.sources,
+    sources: args.sources.map(
+      (distributionIri: string) => new IRI(distributionIri)
+    ),
     query: args.query,
   });
   return results.map((result: QueryResult) => {
     return {
       source: {
-        identifier: result.dataset.identifier,
-        name: result.dataset.name,
+        uri: result.distribution.iri,
+        name: context.catalog.getDatasetByDistributionIri(
+          result.distribution.iri
+        )?.name,
       },
       terms: result.terms.map((term: Term) => {
         return {

--- a/src/server/schema.ts
+++ b/src/server/schema.ts
@@ -1,6 +1,6 @@
 export const schema = `
   type Source {
-    identifier: ID!
+    uri: ID!
     name: String!
   }
 

--- a/src/services/distributions.ts
+++ b/src/services/distributions.ts
@@ -54,7 +54,7 @@ export class DistributionsService {
     const dataset = await this.catalog.getDatasetByDistributionIri(args.source);
     if (dataset === undefined) {
       throw Error(
-        `Source with distribution IRI "${args.source}" not found in catalog`
+        `Source with URI "${args.source}" not found`
       );
     }
     const distribution = dataset.getDistributionByIri(args.source)!;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "./node_modules/gts/tsconfig-google.json",
   "compilerOptions": {
+    "lib": ["es2019"],
     "rootDir": "src",
     "outDir": "build",
     "skipLibCheck": true,


### PR DESCRIPTION
* Fix #17.
* Adapt to https://github.com/netwerk-digitaal-erfgoed/network-of-terms-catalog/pull/9.
* Replace dataset identifier with distribution IRI in both code and docs.