### PR TITLE
Redirect / to /playground

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -28,6 +28,13 @@ async function startServer(): Promise<void> {
       }),
   });
   server.register(fastifyCors);
+  server.route({
+    method: 'GET',
+    url: '/',
+    handler: (req, reply) => {
+      reply.redirect('/playground');
+    },
+  });
   await server.listen(3123, '0.0.0.0');
 }
 


### PR DESCRIPTION
Currently, / shows a 404, so redirect to /playground to give
users a meaningful homepage.